### PR TITLE
Update gatsby repository URL

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -4,7 +4,7 @@
   "description": "Gatsby Plugin for Nx",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nrwl/nx.git",
+    "url": "https://github.com/nrwl/nx-labs.git",
     "directory": "packages/gatsby"
   },
   "keywords": [
@@ -20,7 +20,7 @@
   "author": "Victor Savkin",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nrwl/nx/issues"
+    "url": "https://github.com/nrwl/nx-labs/issues"
   },
   "homepage": "https://nx.dev",
   "schematics": "./generators.json",


### PR DESCRIPTION
Looks like the URL wasn't updated after migrating to this repo, which made it hard to find the package's actual home