### PR TITLE
Fix typo in ExpoBuildIOSOptions type

### DIFF
--- a/packages/expo/src/executors/build-ios/schema.d.ts
+++ b/packages/expo/src/executors/build-ios/schema.d.ts
@@ -17,7 +17,7 @@ export interface ExpoBuildIOSOptions {
   pushP8Path?: string;
   provisioningProfile?: string;
   publicUrl?: string;
-  skipCredentialsCheck?: booolean;
+  skipCredentialsCheck?: boolean;
   skipWorkflowCheck?: boolean;
   sync: boolean; // default is true
 }


### PR DESCRIPTION
Well, this was pretty clearly wrong.