### PR TITLE
feat(repo): convert nx-release.js to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "nx build",
-    "nx-release": "./scripts/nx-release.js",
+    "nx-release": "./scripts/nx-release.mjs",
     "check-versions": "ts-node -P ./tools/tsconfig.tools.json ./tools/scripts/check-versions.ts",
     "start": "nx serve",
     "test": "nx test"
@@ -18,7 +18,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-is": "18.2.0",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
     "@nrwl/cli": "14.4.2",

--- a/scripts/nx-release.mjs
+++ b/scripts/nx-release.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
-const yargsParser = require('yargs-parser');
-const releaseIt = require('release-it');
-const childProcess = require('child_process');
-const fs = require('fs');
-const path = require('path');
+import yargsParser from 'yargs-parser';
+import releaseIt from 'release-it';
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = path.dirname(__filename);
 
 const parsedArgs = yargsParser(process.argv, {
   boolean: ['dry-run', 'local'],
@@ -108,7 +113,7 @@ if (!parsedVersion.isValid) {
   console.error(
     `Please run "yarn nx-release --help" for details on the acceptable version format.\n`
   );
-  return process.exit(1);
+  process.exit(1);
 } else {
   console.log('parsed version: ', JSON.stringify(parsedVersion));
 }

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ##################################################
-# This shell script is executed by nx-release.js #
+# This shell script is executed by nx-release.mjs #
 ##################################################
 
 NX_VERSION=$1

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ##################################################
-# This shell script is executed by nx-release.js #
+# This shell script is executed by nx-release.mjs #
 ##################################################
 
 VERSION=$1

--- a/yarn.lock
+++ b/yarn.lock
@@ -12013,6 +12013,11 @@ yargs-parser@21.0.1, yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"


### PR DESCRIPTION
This PR converts `nx-release.js` to ESM. This to account for #97 which updated the `release-it` package to `15.2` which uses ESM only. This broke the `nx-release.js` script since it couldn't import the ESM module.

Long-term, we should probably transition this repo to use the same release process as the main Nx repo, but this unblocks us for now.