### PR TITLE
fix(nx-ignore): baseSha empty on vercel

### DIFF
--- a/packages/nx-ignore/src/index.ts
+++ b/packages/nx-ignore/src/index.ts
@@ -6,7 +6,7 @@ const project = args.find((s) => !s.startsWith('-')) as string;
 const customBase = args.find((s) => s.startsWith('--base=')) as string;
 const vercelBase = process.env['VERCEL_GIT_PREVIOUS_SHA'];
 const isVerbose = args.some((s) => s === '--verbose');
-const baseSha = customBase ? customBase.slice(7) : vercelBase ?? 'HEAD^';
+const baseSha = customBase ? customBase.slice(7) : vercelBase || 'HEAD^';
 const headSha = 'HEAD';
 
 if (!project) {


### PR DESCRIPTION
The `VERCEL_GIT_PREVIOUS_SHA` can be an empty string on Vercel.
The current logic doesn't handle the env variable being an empty string, therefore we need to change it to logical or.

`printenv` on vercel:
![Screenshot 2022-09-01 at 09 40 38](https://user-images.githubusercontent.com/9988446/187885646-78b163bf-31df-4d6b-b5a5-81f1cc173269.png)

When run in `--verbose` mode on 14.6.0.
![Screenshot 2022-09-01 at 09 50 39](https://user-images.githubusercontent.com/9988446/187885873-10f0752c-3358-4996-9066-60b15da1e6e0.png)
