### PR TITLE
fix(expo): correct eas-cli build:info parameters names

### DIFF
--- a/packages/expo/src/executors/build-list/build-list.impl.ts
+++ b/packages/expo/src/executors/build-list/build-list.impl.ts
@@ -41,11 +41,11 @@ function createBuildListOptions(options: ExpoEasBuildListOptions): string[] {
     if (!nxOptions.includes(k)) {
       if (typeof v === 'boolean') {
         if (v === true) {
-          // when true, does not need to pass the value true, just need to pass the flag in kebob case
-          acc.push(`--${names(k).fileName}`);
+          // when true, does not need to pass the value true, just need to pass the flag in camel case
+          acc.push(`--${names(k).propertyName}`);
         }
       } else {
-        acc.push(`--${names(k).fileName}`, v);
+        acc.push(`--${names(k).propertyName}`, v);
       }
     }
     return acc;


### PR DESCRIPTION
The `eas-cli build:info` command uses camelcase for its parameter names:
```shell
npx eas-cli build:list --help
list all builds for your project

USAGE
  $ eas build:list [--platform all|android|ios] [--json] [--status new|in-queue|in-progress|errored|finished|canceled] [--distribution store|internal|simulator] [--channel <value>]
    [--appVersion <value>] [--appBuildVersion <value>] [--sdkVersion <value>] [--runtimeVersion <value>] [--appIdentifier <value>] [--buildProfile <value>] [--gitCommitHash <value>] [--limit
    <value>]

FLAGS
  --appBuildVersion=<value>
  --appIdentifier=<value>
  --appVersion=<value>
  --buildProfile=<value>
  --channel=<value>
  --distribution=(store|internal|simulator)
  --gitCommitHash=<value>
  --json                                                         Enable JSON output, non-JSON messages will be printed to stderr
  --limit=<value>
  --platform=(all|android|ios)
  --runtimeVersion=<value>
  --sdkVersion=<value>
  --status=(new|in-queue|in-progress|errored|finished|canceled)

DESCRIPTION
  list all builds for your project
```

I verified this is true for versions `0.55.1` and `2.1.0`. This leads the following error when setting any parameter with a multi-word name in either the built-list or download executors:
```shell
Command failed: ./node_modules/eas-cli/bin/run build:list --build-profile simulator --platform ios --json --status finished --limit 1

 ›   Error: Unexpected arguments: --build-profile, simulator
 ›   See more help with --help
```