### PR TITLE
fix(nx-ignore): re-use Nx CLI installed to workspace rather than have a dependency to it

### DIFF
--- a/packages/nx-ignore/README.md
+++ b/packages/nx-ignore/README.md
@@ -15,7 +15,8 @@ npx nx-ignore <project-name>
 ### Options
 
 - `--base` - Set a custom base SHA to compare changes (defaults to [`VERCEL_GIT_PREVIOUS_SHA`](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables)).
-- `--verbose` - Log more details information for debugging purposes
+- ``--root` - Set a custom workspace root (defaults to current working directory).
+- `--verbose` - Log more details information for debugging purposes.
 
 ## How it works
 

--- a/packages/nx-ignore/package.json
+++ b/packages/nx-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nx-ignore",
-  "version": "15.0.0",
+  "version": "15.5.0-beta.0",
   "type": "commonjs",
   "repository": {
     "type": "git",
@@ -19,9 +19,6 @@
     "nx-ignore": "./src/index.js"
   },
   "dependencies": {
-    "@swc/helpers": "^0.4.11",
-    "nx": "~15.0.4",
-    "@nrwl/workspace": "~15.0.4",
-    "typescript": "~4.8.2"
+    "@swc/helpers": "^0.4.14"
   }
 }

--- a/packages/nx-ignore/src/index.ts
+++ b/packages/nx-ignore/src/index.ts
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { execSync } = require('child_process');
-const { findWorkspaceRoot } = require('nx/src/utils/find-workspace-root');
-const {
-  createProjectGraphAsync,
-} = require('nx/src/project-graph/project-graph');
-const { affected } = require('nx/src/command-line/affected');
+const { existsSync, readFileSync, renameSync, writeFileSync } = require('fs');
+const { join } = require('path');
 
 const args = process.argv.slice(2);
 const project = args.find((s) => !s.startsWith('-')) as string;
 const customBase = args.find(
   (s) => s.startsWith('--base=') || s.startsWith('--base ')
 ) as string;
+const customRoot = args.find(
+  (s) => s.startsWith('--root=') || s.startsWith('--root ')
+) as string;
 const vercelBase = process.env['VERCEL_GIT_PREVIOUS_SHA'];
 const isVerbose = args.some((s) => s === '--verbose');
 const headSha = 'HEAD';
+const userDefinedRoot = customRoot ? customRoot.slice(7) : null;
 let baseSha = customBase ? customBase.slice(7) : vercelBase || 'HEAD^';
 
 if (!project) {
@@ -29,19 +30,24 @@ console.log(
 main();
 
 async function main() {
-  const root = findWorkspaceRoot(process.cwd());
+  const root = userDefinedRoot || process.cwd();
 
-  if (!root) {
-    console.log('≫ Could not find Nx root');
+  logDebug(`≫ Running from ${__dirname}`);
+  logDebug(`≫ Workspace root is ${root}`);
+
+  const nxVersion = ensureNxInstalled(root);
+
+  if (!nxVersion) {
+    console.log('≫ Cannot find installed Nx');
     process.exit(1);
   }
+
+  logDebug(`≫ Found Nx at version ${nxVersion}`);
 
   // Disable daemon so we always generate new graph.
   process.env.NX_DAEMON = 'false';
 
   let result = { projects: [] as string[] };
-
-  logDebug(`≫ Running from ${__dirname}`);
 
   // Branch may not contain last deployed SHA
   if (baseSha !== 'HEAD^') {
@@ -58,35 +64,13 @@ async function main() {
 
   logDebug(`\n≫ Comparing ${baseSha}...${headSha}\n`);
 
-  // TODO(jack): This console.log hack isn't needed if Nx can support being installed outside of cwd.
-  const _log = console.log;
-
-  try {
-    let output = '';
-    console.log = (x) => {
-      output = x;
-    };
-
-    // Ensure graph is created
-    await createProjectGraphAsync();
-
-    // Since Nx currently looks for "nx" package under workspace root, the CLI doesn't work on Vercel.
-    // Call the file directly instead of going through Nx CLI.
-    await affected('print-affected', {
-      type: 'app',
-      base: baseSha,
-      head: headSha,
-      _: '',
-      __overrides_unparsed__: '',
-    });
-
-    result = JSON.parse(output);
-  } catch (e) {
-    console.error(e);
-    process.exit(1);
-  } finally {
-    console.log = _log;
-  }
+  const output = execSync(
+    `npx nx print-affected --base=${baseSha} --head=${headSha}`,
+    {
+      cwd: root,
+    }
+  ).toString();
+  result = JSON.parse(output);
 
   logDebug(`≫ Affected projects:\n  - ${result.projects.join('\n  - ')}\n`);
 
@@ -102,4 +86,76 @@ async function main() {
 
 function logDebug(s: string) {
   if (isVerbose) console.log(s);
+}
+
+export function detectPackageManager(root: string): 'npm' | 'yarn' | 'pnpm' {
+  return existsSync(join(root, 'yarn.lock'))
+    ? 'yarn'
+    : existsSync(join(root, 'pnpm-lock.yaml'))
+    ? 'pnpm'
+    : 'npm';
+}
+
+// This function ensures that Nx is installed in the workspace.
+// Returns the version of Nx if found, null otherwise.
+function ensureNxInstalled(root: string): string | null {
+  try {
+    const packageJson = require(join(root, 'package.json'));
+    const deps = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+    const pm = detectPackageManager(root);
+
+    // create temp package.json to avoid install other packages
+    const json = JSON.parse(readFileSync(join(root, 'package.json')));
+    renameSync(join(root, 'package.json'), join(root, 'package.original.json'));
+    delete json['scripts'];
+    delete json.dependencies;
+    json.devDependencies = {
+      nx: deps['nx'],
+      next: deps['next'],
+      typescript: deps['typescript'],
+    };
+    writeFileSync(join(root, 'package.json'), JSON.stringify(json));
+
+    if (pm === 'npm') {
+      renameSync(
+        join(root, 'package-lock.json'),
+        join(root, 'package-lock.original.json')
+      );
+      execSync(`npm install`);
+    } else if (pm === 'yarn') {
+      renameSync(join(root, 'yarn.lock'), join(root, 'yarn.original.lock'));
+      execSync(`yarn install`);
+    } else {
+      renameSync(
+        join(root, 'pnpm-lock.yaml'),
+        join(root, 'pnpm-lock.original.yaml')
+      );
+      execSync(`pnpm install`);
+    }
+
+    // Rename package.json back so build can continue as normal
+    renameSync(join(root, 'package.original.json'), join(root, 'package.json'));
+    if (pm === 'npm') {
+      renameSync(
+        join(root, 'package-lock.original.json'),
+        join(root, 'package-lock.json')
+      );
+    } else if (pm === 'yarn') {
+      renameSync(join(root, 'yarn.original.lock'), join(root, 'yarn.lock'));
+    } else {
+      renameSync(
+        join(root, 'pnpm-lock.original.yaml'),
+        join(root, 'pnpm-lock.yaml')
+      );
+    }
+
+    return deps['nx'];
+  } catch {
+    // nothing
+  }
+
+  return null;
 }


### PR DESCRIPTION
This PR reworks the `nx-ignore` package to ensure Nx is installed in the workspace root, and use that exact version rather than have a dependency on `nx`.

This removes weirdness around how to invoke `print-affected` and potential version mismatches (which can result in invalid paths, etc.).

Also add a `--root` option for debugging purposes, and if Vercel ever change the way things are executed we'd have a workaround.

## What's next

Once we have a globally runnable `nx` command that does not depend on `node_modules` we can update this package to use that instead.

## Issues

Fixes #131