### PR TITLE
fix(nx-ignore): install Nx to a temp location to avoid touching workspace files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chalk": "4.1.2",
     "eslint": "8.15.0",
     "eslint-config-prettier": "8.1.0",
+    "fs-extra": "^10.1.0",
     "jest": "28.1.3",
     "jest-environment-jsdom": "^29.0.1",
     "metro-resolver": "0.71.0",

--- a/packages/nx-ignore/package.json
+++ b/packages/nx-ignore/package.json
@@ -19,6 +19,7 @@
     "nx-ignore": "./src/index.js"
   },
   "dependencies": {
+    "fs-extra": "^10.1.0",
     "@swc/helpers": "^0.4.14"
   }
 }


### PR DESCRIPTION
This PR updates the Nx install to a temp location, then move it to the workspace root. This allows Nx install to be found without touching `package.json` and lockfiles.