### PR TITLE
feat(nx-ignore): add support for third-party plugins when building Nx graph

### DIFF
--- a/packages/nx-ignore/README.md
+++ b/packages/nx-ignore/README.md
@@ -15,7 +15,8 @@ npx nx-ignore <project-name>
 ### Options
 
 - `--base` - Set a custom base SHA to compare changes (defaults to [`VERCEL_GIT_PREVIOUS_SHA`](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables)).
-- ``--root` - Set a custom workspace root (defaults to current working directory).
+- `--plugins` - List of Nx plugins required (i.e. plugins that extend the Nx graph). Default plugins are read from nx.json.
+- `--root` - Set a custom workspace root (defaults to current working directory).
 - `--verbose` - Log more details information for debugging purposes.
 
 ## How it works


### PR DESCRIPTION
This PR adds a `--plugins` option to `nx-ignore` so users can specify additional plugins to install that are required for graph extensions. By default, pick up plugins from `nx.json` and install the ones that are found in `package.json`.

## Example

If `nx.json` has the following:
```json
{
  "plugins" ["@monodon/rust"]
}
```

Then running `npx nx-ignore nx-dev --verbose` in the Nx repo should install that plugin before building project graph.

Output is like this:


```bash
≫ Using Nx to determine if this project (nx-dev) is affected by the commit...
≫ Running from /Users/jack/projects/nx-labs/dist/packages/nx-ignore/src
≫ Workspace root is /Users/jack/projects/nx
≫ Creating temp folder to install Nx: /var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/.nx-ignore
≫ Ignore plugin @monodon/rust (workspace plugins do no need to be installed)
≫ Found Nx at version 15.6.0-beta.1

≫ Comparing HEAD^...HEAD

≫ Affected projects:
  - docs
  - nx-dev
  - nx-dev-e2e
  - @nrwl/nx-source
  - create-nx-workspace
  - e2e-workspace-create
  - node
  - express
  - nest
  - e2e-node

✅ - Build can proceed since nx-dev is affected
```
