### PR TITLE
feat(nx-ignore): add ability to skip or force deploys from commit message

### DIFF
--- a/e2e/nx-ignore-e2e/jest.config.js
+++ b/e2e/nx-ignore-e2e/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'nx-ignore-e2e',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/e2e/nx-ignore-e2e',
+};

--- a/e2e/nx-ignore-e2e/project.json
+++ b/e2e/nx-ignore-e2e/project.json
@@ -1,0 +1,15 @@
+{
+  "projectType": "application",
+  "sourceRoot": "e2e/nx-ignore-e2e/src",
+  "targets": {
+    "e2e": {
+      "executor": "@nrwl/nx-plugin:e2e",
+      "options": {
+        "target": "nx-ignore:build",
+        "jestConfig": "e2e/nx-ignore-e2e/jest.config.js"
+      }
+    }
+  },
+  "tags": [],
+  "implicitDependencies": ["nx-ignore"]
+}

--- a/e2e/nx-ignore-e2e/tests/nx-ignore.spec.ts
+++ b/e2e/nx-ignore-e2e/tests/nx-ignore.spec.ts
@@ -1,0 +1,75 @@
+import { join } from 'path';
+import { mkdirSync, writeFileSync } from 'fs-extra';
+
+import {
+  ensureNxProject,
+  runCommand,
+  tmpProjPath,
+  uniq,
+} from '@nrwl/nx-plugin/testing';
+
+describe('nx-ignore e2e', () => {
+  let proj: string;
+  let projRoot: string;
+
+  beforeEach(() => {
+    proj = uniq('proj');
+    projRoot = join(tmpProjPath(), proj);
+    ensureNxProject('nx-ignore', 'dist/packages/nx-ignore');
+
+    // Add a test project we can make changes to
+    mkdirSync(projRoot, { recursive: true });
+    writeFileSync(join(projRoot, 'main.ts'), `console.log('hello');\n`);
+    writeFileSync(
+      join(tmpProjPath(), 'project.json'),
+      JSON.stringify(
+        {
+          name: proj,
+          root: projRoot,
+        },
+        null,
+        2
+      )
+    );
+    runCommand(`git init`);
+    runCommand(`git add .`);
+    runCommand(`git commit -m 'init'`);
+  });
+
+  it('should deploy if the latest commit touches the project', async () => {
+    writeFileSync(join(projRoot, 'main.ts'), `console.log('bye');\n`);
+    runCommand('git commit -am "update main"');
+
+    let result = runCommand(`npx nx-ignore ${proj}`);
+    expect(result).toMatch(/Build can proceed/);
+
+    runCommand('git commit -m "nothing" --allow-empty');
+    result = runCommand(`npx nx-ignore ${proj}`);
+    expect(result).toMatch(/Build cancelled/);
+  }, 120_000);
+
+  it('should skip deploy based on commit message', async () => {
+    [
+      '[ci skip] test',
+      '[skip ci] test',
+      '[no ci] test',
+      '[nx skip] test',
+      `[nx skip ${proj}] test`,
+    ].forEach((msg) => {
+      writeFileSync(join(projRoot, 'main.ts'), `console.log('bye');\n`);
+      runCommand(`git commit -am "${msg}"`);
+
+      const result = runCommand(`npx nx-ignore ${proj}`);
+      expect(result).toMatch(/Skip build/);
+    });
+  }, 120_000);
+
+  it('should force deploy based on commit message', async () => {
+    ['[nx deploy] test', `[nx deploy ${proj}] test`].forEach((msg) => {
+      runCommand(`git commit -m "${msg}" --allow-empty`);
+
+      const result = runCommand(`npx nx-ignore ${proj}`);
+      expect(result).toMatch(/Force build/);
+    });
+  }, 120_000);
+});

--- a/e2e/nx-ignore-e2e/tsconfig.json
+++ b/e2e/nx-ignore-e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.e2e.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/e2e/nx-ignore-e2e/tsconfig.spec.json
+++ b/e2e/nx-ignore-e2e/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/packages/nx-ignore/README.md
+++ b/packages/nx-ignore/README.md
@@ -19,6 +19,20 @@ npx nx-ignore <project-name>
 - `--root` - Set a custom workspace root (defaults to current working directory).
 - `--verbose` - Log more details information for debugging purposes.
 
+### Skipping and forcing deployment
+
+Skip nx-ignore check and ignore deployment:
+
+- [skip ci]
+- [ci skip]
+- [no ci]
+- [nx skip <app>]
+
+Skip nx-ignore check and force deployment:
+
+- [nx deploy]
+- [nx deploy <app>]
+
 ## How it works
 
 The `nx-ignore` command uses Nx to determine whether the current commit affects the specified app. It exits with an error code (1) when the app is affected, which tells Vercel to continue the build, otherwise it exits successfully, which tells Vercel to cancel the build.


### PR DESCRIPTION
This PR adds a check for the commit message to determine if the build should be skipped or forced to build.

Logic is as follows:

```
Skip nx-ignore check and ignore deployment:

- [skip ci]
- [ci skip]
- [no ci]
- [nx skip <app>]

Skip nx-ignore check and force deployment:

- [nx deploy]
- [nx deploy <app>]
```

For example, `git commit -m '[nx deploy] something'` will force all apps to deploy, and `git commit -m [nx skip]` will skip deploys for all apps.

Closes #133
