### PR TITLE
fix(deno) buildTarget should not be required for the @nrwl/deno:run executor

### DIFF
--- a/packages/deno/src/executors/run/run.impl.ts
+++ b/packages/deno/src/executors/run/run.impl.ts
@@ -49,7 +49,7 @@ function normalizeOptions(
   options: ServeExecutorSchema,
   context: ExecutorContext
 ) {
-  let mergedOptions: ServeExecutorSchema;
+  let mergedOptions: ServeExecutorSchema = options;
   if (options.buildTarget) {
     const target = parseTargetString(options.buildTarget, context.projectGraph);
     const buildTargetOptions = readTargetOptions<BuildExecutorSchema>(

--- a/packages/deno/src/generators/application/generator.ts
+++ b/packages/deno/src/generators/application/generator.ts
@@ -30,7 +30,12 @@ function normalizeOptions(
     ? `${names(options.directory).fileName}/${name}`
     : name;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${projectDirectory}`;
+  const appDir = getWorkspaceLayout(tree).appsDir;
+  // prevent paths from being dist/./app-name
+  const projectRoot = joinPathFragments(
+    appDir === '.' ? '' : appDir,
+    projectDirectory
+  );
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];

--- a/packages/deno/src/generators/library/library.ts
+++ b/packages/deno/src/generators/library/library.ts
@@ -32,7 +32,12 @@ function normalizeOptions(
     ? `${names(options.directory).fileName}/${name}`
     : name;
   const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree).libsDir}/${projectDirectory}`;
+  const libDir = getWorkspaceLayout(tree).libsDir;
+  // prevent paths from being dist/./lib-name
+  const projectRoot = joinPathFragments(
+    libDir === '.' ? '' : libDir,
+    projectDirectory
+  );
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];

--- a/packages/deno/src/generators/utils/add-path.ts
+++ b/packages/deno/src/generators/utils/add-path.ts
@@ -7,13 +7,18 @@ export function addPathToDenoSettings(tree: Tree, path: string) {
     tree.write(vscodeSettingsPath, JSON.stringify({ enablePaths: [] }));
   }
 
-  updateJson(tree, vscodeSettingsPath, (json) => {
-    const paths = new Set(json['deno.enablePaths'] || []);
+  updateJson(
+    tree,
+    vscodeSettingsPath,
+    (json) => {
+      const paths = new Set(json['deno.enablePaths'] || []);
 
-    paths.add(path);
+      paths.add(path);
 
-    json['deno.enablePaths'] = Array.from(paths);
+      json['deno.enablePaths'] = Array.from(paths);
 
-    return json;
-  });
+      return json;
+    },
+    { expectComments: true, allowTrailingComma: true }
+  );
 }


### PR DESCRIPTION
the @nrwl/deno:run executor requires a buildTarget in order to not throw an error about not being able to read 'main' of undefined.

this is because the 'mergedOptions' is not defaulted and is only assigned when a buildTarget is provided. 

instead the mergedOptions should be defaulted to the incoming options and then if there is a buildTarget to combined the resolved build options with the existing defined options passed into @nrwl/deno:run executor.

This PR also fixes an issue where when using nx in a root level project (standalone) the generated paths in the project configurations would contain a '.' for the 'projectRoot'. while technically a valid path, it looks ugly. Now the path is checked to see if the root is a '.' and omits that part of the path if that's the case. 