### PR TITLE
fix(deno): emit once when running in watch mode

### DIFF
--- a/packages/deno/src/executors/run/run.impl.ts
+++ b/packages/deno/src/executors/run/run.impl.ts
@@ -36,6 +36,13 @@ export async function* denoServeExecutor(
       process.exit(128 + 1);
     });
 
+    // need to emit a success for other executors that
+    // might be waiting on this dev server in watch mode
+    // i.e. @nrwl/cypress
+    if (opts.watch) {
+      next({ success: true });
+    }
+
     runningDenoProcess.on('exit', (code) => {
       next({ success: code === 0 });
       if (!opts.watch) {


### PR DESCRIPTION
When using executors like @nrwl/cypress an initial event needs to be emitted so it knows to continue running, this only applies to watch mode for the executors  