### PR TITLE
feat(rspack): clean-up project setup

### DIFF
--- a/packages/rspack/generators.json
+++ b/packages/rspack/generators.json
@@ -3,10 +3,10 @@
   "name": "rspack",
   "version": "0.0.1",
   "generators": {
-    "rspack-project": {
-      "factory": "./src/generators/rspack-project/rspack-project",
-      "schema": "./src/generators/rspack-project/schema.json",
-      "description": "Rspack project generator."
+    "configuration": {
+      "factory": "./src/generators/configuration/configuration",
+      "schema": "./src/generators/configuration/schema.json",
+      "description": "Rspack configuration generator."
     },
     "init": {
       "factory": "./src/generators/init/init",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -22,8 +22,8 @@
     "@nrwl/linter": "^15.8.1",
     "@nrwl/devkit": "^15.8.1",
     "ajv": "^8.12.0",
+    "less-loader": "11.1.0",
     "sass-loader": "^12.2.0",
-    "stylus-loader": "^7.1.0",
-    "less-loader": "11.1.0"
+    "stylus-loader": "^7.1.0"
   }
 }

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -1,4 +1,6 @@
 import { ExecutorContext } from '@nrwl/devkit';
+import { rmSync } from 'fs';
+import * as path from 'path';
 import { createCompiler } from '../../utils/create-compiler';
 import { RspackExecutorSchema } from './schema';
 
@@ -7,6 +9,12 @@ export default async function runExecutor(
   context: ExecutorContext
 ) {
   process.env.NODE_ENV ??= 'production';
+
+  // Mimic --clean from webpack.
+  rmSync(path.join(context.root, options.outputPath), {
+    force: true,
+    recursive: true,
+  });
 
   const compiler = await createCompiler(options, context);
 

--- a/packages/rspack/src/generators/application/application.ts
+++ b/packages/rspack/src/generators/application/application.ts
@@ -21,7 +21,7 @@ import {
   typesReactDomVersion,
   typesReactVersion,
 } from '../../utils/versions';
-import projectGenerator from '../rspack-project/rspack-project';
+import { configurationGenerator } from '../configuration/configuration';
 import { addCypress } from './lib/add-cypress';
 import { addJest } from './lib/add-jest';
 import { addLinting } from './lib/add-linting';
@@ -63,7 +63,7 @@ export default async function (
     joinPathFragments(offsetFromRoot, 'tsconfig.base.json')
   );
 
-  const projectTask = await projectGenerator(tree, {
+  const projectTask = await configurationGenerator(tree, {
     project: options.name,
     devServer: true,
     tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),

--- a/packages/rspack/src/generators/configuration/schema.d.ts
+++ b/packages/rspack/src/generators/configuration/schema.d.ts
@@ -1,6 +1,6 @@
 import { InitGeneratorSchema } from '../init/schema';
 
-export interface RspackProjectGeneratorSchema extends InitGeneratorSchema {
+export interface ConfigurationSchema extends InitGeneratorSchema {
   project: string;
   main?: string;
   tsConfig?: string;

--- a/packages/rspack/src/generators/configuration/schema.json
+++ b/packages/rspack/src/generators/configuration/schema.json
@@ -46,12 +46,6 @@
       "type": "string",
       "description": "The style solution to use.",
       "enum": ["none", "css", "scss", "less"]
-    },
-    "skipValidation": {
-      "type": "boolean",
-      "default": false,
-      "description": "Do not perform any validation on existing project.",
-      "x-priority": "internal"
     }
   },
   "required": ["project"]

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -1,5 +1,5 @@
+export * from './generators/configuration/configuration';
 export * from './generators/init/init';
-export * from './generators/rspack-project/rspack-project';
 export * from './utils/config';
 export * from './utils/with-nx';
 export * from './utils/with-react';


### PR DESCRIPTION
This PR cleans up the rspack project setup.

- `outputPath` is `dist/<app>` for standalone apps not just `dist` (same as React plugin).
- Clean output before build.
- Generate `development` configuration for `build` and `serve` targets so apps are run in dev-mode when serving.
- Rename `@nrwl/rspack:rspack-project` to `@nrwl/rspack:configuration` to match Vite setup, and removed validation since users can always git reset.