### PR TITLE
fix(rspack): use correct app dir when generating non-root projects

### DIFF
--- a/e2e/rspack-e2e/tests/rspack.spec.ts
+++ b/e2e/rspack-e2e/tests/rspack.spec.ts
@@ -1,4 +1,5 @@
 import {
+  checkFilesExist,
   ensureNxProject,
   listFiles,
   runNxCommandAsync,
@@ -23,7 +24,7 @@ describe('rspack e2e', () => {
     runNxCommandAsync('reset');
   });
 
-  it('should create rspack project', async () => {
+  it('should create rspack root project and additional apps', async () => {
     const project = uniq('myapp');
     await runNxCommandAsync(
       `generate @nrwl/rspack:preset ${project} --unitTestRunner=jest --e2eTestRunner=cypress`
@@ -54,5 +55,27 @@ describe('rspack e2e', () => {
     });
     expect(result.stdout).toContain('Successfully ran target build');
     expect(listFiles(`dist/${project}`)).toHaveLength(5); // same length as before
+
+    // Generate a new app and check that the files are correct
+    const app2 = uniq('app2');
+    await runNxCommandAsync(
+      `generate @nrwl/rspack:app ${app2} --unitTestRunner=jest --e2eTestRunner=cypress --style=css`
+    );
+    checkFilesExist(`${app2}/project.json`, `${app2}-e2e/project.json`);
+    result = await runNxCommandAsync(`build ${app2}`, {
+      env: { NODE_ENV: 'production' },
+    });
+    expect(result.stdout).toContain('Successfully ran target build');
+    // Make sure expected files are present.
+    expect(listFiles(`dist/${app2}`)).toHaveLength(5);
+
+    result = await runNxCommandAsync(`lint ${app2}`);
+    expect(result.stdout).toContain('Successfully ran target lint');
+
+    result = await runNxCommandAsync(`test ${app2}`);
+    expect(result.stdout).toContain('Successfully ran target test');
+
+    result = await runNxCommandAsync(`e2e ${app2}-e2e`);
+    expect(result.stdout).toContain('Successfully ran target e2e');
   }, 120_000);
 });

--- a/packages/rspack/src/generators/application/lib/normalize-options.spec.ts
+++ b/packages/rspack/src/generators/application/lib/normalize-options.spec.ts
@@ -1,0 +1,51 @@
+import { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { normalizeOptions } from './normalize-options';
+
+describe('normalizeOptions', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should set { rootProject: true } when --rootProject=true is passed', () => {
+    expect(
+      normalizeOptions(tree, {
+        name: 'demo',
+        style: 'css',
+        rootProject: true,
+      }).rootProject
+    ).toBeTruthy();
+  });
+
+  it('should set { rootProject: false } when --rootProject=undefined is passed', () => {
+    expect(
+      normalizeOptions(tree, {
+        name: 'demo',
+        style: 'css',
+      }).rootProject
+    ).toBeFalsy();
+  });
+
+  it('should set { rootProject: false } when --rootProject=false is passed', () => {
+    expect(
+      normalizeOptions(tree, {
+        name: 'demo',
+        style: 'css',
+        rootProject: false,
+      }).rootProject
+    ).toBeFalsy();
+  });
+
+  it('should set { rootProject: false } when --monorepo=true and --rootProject=true is passed', () => {
+    expect(
+      normalizeOptions(tree, {
+        name: 'demo',
+        style: 'css',
+        monorepo: true,
+        rootProject: true,
+      }).rootProject
+    ).toBeFalsy();
+  });
+});

--- a/packages/rspack/src/generators/application/lib/normalize-options.ts
+++ b/packages/rspack/src/generators/application/lib/normalize-options.ts
@@ -24,7 +24,7 @@ export function normalizeOptions(
 ): NormalizedSchema {
   // --monorepo takes precedence over --rootProject
   // This won't be needed once we add --bundler=rspack to the @nrwl/react:app preset
-  const rootProject = !options.monorepo && (options.rootProject ?? true);
+  const rootProject = !options.monorepo && options.rootProject;
   const appDirectory = normalizeDirectory(options);
   const appProjectName = normalizeProjectName(options);
   const e2eProjectName = options.rootProject


### PR DESCRIPTION
This PR fixes an issue where app directory is incorrectly set to project root when generating subsequent rspack apps.

Since `@nrwl/rspack:preset` and `@nrwl/rspack:app` generators are separate now, we can set `rootProject` default only in `preset` and not `app`.