### PR TITLE
fix(remix): dependencies version mismatch

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -7,6 +7,7 @@
     "@nrwl/devkit": "^14.5.0",
     "@nrwl/js": "^14.5.0",
     "@nrwl/react": "^14.5.0",
+    "nx": "^14.5.0",
     "tslib": "^2.3.1"
   },
   "ng-update": {


### PR DESCRIPTION
There is a mismatch between the versions of `@nrwl/devkit` and `nx`. Remix depends on `"^14.5.0"`, which resolves to `14.7.0`, and when you try to add `@nrwl/remix` on a repo, it uses the old devkit but with the new Nx. Starting with version `15.7.0` Nx does not contain the `shouldDefaultToUsingStandaloneConfigs` function, which causes an error. 

I am NOT sure if this is the solution, or if we could update the other `@nlrw/*` packages to the latest Nx, or just Nx `>=15.7.0`.

Related issues:
* https://github.com/nrwl/nx-labs/issues/145 
* https://github.com/nrwl/nx-labs/issues/164
* https://github.com/nrwl/nx-labs/issues/148