### PR TITLE
feat(deno): QoL improvements for generators

### DIFF
--- a/e2e/deno-e2e/tests/deno-misc.spec.ts
+++ b/e2e/deno-e2e/tests/deno-misc.spec.ts
@@ -16,10 +16,10 @@ describe('Deno Misc Tests', () => {
     ensureNxProject('@nrwl/deno', 'dist/packages/deno');
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     // `nx reset` kills the daemon, and performs
     // some work which can help clean up e2e leftovers
-    runNxCommandAsync('reset');
+    await runNxCommandAsync('reset');
   });
 
   it('should add existing project to deno imports', async () => {

--- a/e2e/deno-e2e/tests/deno-misc.spec.ts
+++ b/e2e/deno-e2e/tests/deno-misc.spec.ts
@@ -1,0 +1,44 @@
+import {
+  ensureNxProject,
+  runNxCommand,
+  runNxCommandAsync,
+  updateFile,
+} from '@nrwl/nx-plugin/testing';
+
+describe('Deno Misc Tests', () => {
+  // Setting up individual workspaces per
+  // test can cause e2e runs to take a long time.
+  // For this reason, we recommend each suite only
+  // consumes 1 workspace. The tests should each operate
+  // on a unique project in the workspace, such that they
+  // are not dependant on one another.
+  beforeAll(() => {
+    ensureNxProject('@nrwl/deno', 'dist/packages/deno');
+  });
+
+  afterAll(() => {
+    // `nx reset` kills the daemon, and performs
+    // some work which can help clean up e2e leftovers
+    runNxCommandAsync('reset');
+  });
+
+  it('should add existing project to deno imports', async () => {
+    await runNxCommandAsync('generate @nrwl/deno:app api');
+    await runNxCommandAsync('generate @nrwl/js:lib my-types');
+    // change my-types index.ts file to be deno compatible
+    updateFile(
+      'libs/my-types/src/index.ts',
+      `export const myType = () => 'myType';`
+    );
+    await runNxCommandAsync('generate @nrwl/deno:add-import my-types');
+    updateFile(
+      'apps/api/src/main.ts',
+      `import { myType } from '@proj/my-types';
+console.log(myType());`
+    );
+
+    expect(() => {
+      runNxCommand('serve api --watch=false');
+    }).not.toThrow();
+  }, 120_000);
+});

--- a/packages/deno/generators.json
+++ b/packages/deno/generators.json
@@ -28,6 +28,11 @@
       "factory": "./src/generators/preset/generator",
       "schema": "./src/generators/preset/schema.json",
       "description": "preset generator"
+    },
+    "add-import": {
+      "factory": "./src/generators/add-import/generator",
+      "schema": "./src/generators/add-import/schema.json",
+      "description": "add-import generator"
     }
   }
 }

--- a/packages/deno/generators.json
+++ b/packages/deno/generators.json
@@ -7,17 +7,13 @@
       "factory": "./src/generators/application/generator",
       "schema": "./src/generators/application/schema.json",
       "description": "Create a new Deno application",
-      "aliases": [
-        "app"
-      ]
+      "aliases": ["app"]
     },
     "library": {
       "factory": "./src/generators/library/library",
       "schema": "./src/generators/library/schema.json",
       "description": "Create a new Deno library",
-      "aliases": [
-        "lib"
-      ]
+      "aliases": ["lib"]
     },
     "init": {
       "factory": "./src/generators/init/generator",
@@ -27,12 +23,13 @@
     "preset": {
       "factory": "./src/generators/preset/generator",
       "schema": "./src/generators/preset/schema.json",
-      "description": "preset generator"
+      "description": "Create a new standalone Deno workspace with create-nx-workspace"
     },
     "add-import": {
+      "aliases": ["import", "add"],
       "factory": "./src/generators/add-import/generator",
       "schema": "./src/generators/add-import/schema.json",
-      "description": "add-import generator"
+      "description": "Add an existing library to Deno imports"
     }
   }
 }

--- a/packages/deno/src/executors/bundle/bundle.impl.ts
+++ b/packages/deno/src/executors/bundle/bundle.impl.ts
@@ -4,9 +4,10 @@ import { BuildExecutorSchema } from './schema';
 
 import { ensureDirSync } from 'fs-extra';
 import { processCommonArgs } from '../../utils/arg-utils';
-import { runDeno } from '../../utils/run-deno';
+import { assertDenoInstalled, runDeno } from '../../utils/run-deno';
 
 export async function denoBuildExecutor(options: BuildExecutorSchema) {
+  assertDenoInstalled();
   const opts = normalizeOptions(options);
   const args = createArgs(opts);
 

--- a/packages/deno/src/executors/lint/lint.impl.ts
+++ b/packages/deno/src/executors/lint/lint.impl.ts
@@ -1,6 +1,6 @@
 import { ExecutorContext, ProjectConfiguration } from '@nrwl/devkit';
 import { processCommonArgs } from '../../utils/arg-utils';
-import { runDeno } from '../../utils/run-deno';
+import { assertDenoInstalled, runDeno } from '../../utils/run-deno';
 import { LintExecutorSchema } from './schema';
 
 interface LintExecutorNormalizedSchema extends LintExecutorSchema {
@@ -10,6 +10,7 @@ export async function denoLintExecutor(
   options: LintExecutorSchema,
   context: ExecutorContext
 ) {
+  assertDenoInstalled();
   const projectConfig =
     context.projectGraph?.nodes?.[context.projectName]?.data;
 

--- a/packages/deno/src/executors/run/run.impl.ts
+++ b/packages/deno/src/executors/run/run.impl.ts
@@ -5,7 +5,7 @@ import {
 } from '@nrwl/devkit';
 import { ChildProcess } from 'child_process';
 import { processCommonArgs } from '../../utils/arg-utils';
-import { runDeno } from '../../utils/run-deno';
+import { assertDenoInstalled, runDeno } from '../../utils/run-deno';
 import { BuildExecutorSchema } from '../bundle/schema';
 import { ServeExecutorSchema } from './schema';
 
@@ -15,6 +15,7 @@ export async function* denoServeExecutor(
   options: ServeExecutorSchema,
   context: ExecutorContext
 ) {
+  assertDenoInstalled();
   const opts = normalizeOptions(options, context);
   const args = createArgs(opts);
 

--- a/packages/deno/src/executors/test/test.impl.ts
+++ b/packages/deno/src/executors/test/test.impl.ts
@@ -2,7 +2,7 @@ import { ExecutorContext, logger } from '@nrwl/devkit';
 import { emptyDirSync } from 'fs-extra';
 import { join, posix, resolve, sep } from 'path';
 import { processCommonArgs } from '../../utils/arg-utils';
-import { runDeno } from '../../utils/run-deno';
+import { assertDenoInstalled, runDeno } from '../../utils/run-deno';
 import { DenoTestExecutorSchema } from './schema';
 
 interface DenoTestExecutorNormalizedSchema extends DenoTestExecutorSchema {
@@ -18,6 +18,7 @@ export async function denoTestExecutor(
   options: DenoTestExecutorSchema,
   context: ExecutorContext
 ) {
+  assertDenoInstalled();
   const opts = normalizeOptions(options, context);
 
   const args = createArgs(opts);

--- a/packages/deno/src/generators/add-import/generator.ts
+++ b/packages/deno/src/generators/add-import/generator.ts
@@ -1,0 +1,35 @@
+import {
+  formatFiles,
+  getImportPath,
+  getWorkspaceLayout,
+  readProjectConfiguration,
+  Tree,
+} from '@nrwl/devkit';
+import { addImports, getImportPathForProjectName } from '../utils/imports';
+import { AddImportGeneratorSchema } from './schema';
+
+function normalizeOptions(tree: Tree, options: AddImportGeneratorSchema) {
+  const layout = getWorkspaceLayout(tree);
+
+  return {
+    ...options,
+    projectConfig: readProjectConfiguration(tree, options.project),
+    importPath:
+      options.importPath || getImportPath(layout.npmScope, options.project),
+  };
+}
+
+export default async function (tree: Tree, options: AddImportGeneratorSchema) {
+  const normalizedOptions = normalizeOptions(tree, options);
+  const existingImportPath = getImportPathForProjectName(
+    tree,
+    normalizedOptions.projectConfig
+  );
+
+  addImports(tree, {
+    entryPoints: { deno: existingImportPath.importPath },
+    importPath: existingImportPath.importAlias,
+  });
+
+  await formatFiles(tree);
+}

--- a/packages/deno/src/generators/add-import/schema.d.ts
+++ b/packages/deno/src/generators/add-import/schema.d.ts
@@ -1,0 +1,4 @@
+export interface AddImportGeneratorSchema {
+  project: string;
+  importPath?: string;
+}

--- a/packages/deno/src/generators/add-import/schema.json
+++ b/packages/deno/src/generators/add-import/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "DenoAddImport",
+  "title": "Include existing project in Deno imports",
+  "description": "Add an existing projects tsconfig paths alias to the Deno import_map.json file.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project to add to the import_map.json.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What project would you like to add to the import_map.json?",
+      "x-dropdown": "projects"
+    },
+    "importPath": {
+      "type": "string",
+      "description": "Custom import name to use for the project. Defaults to what is in the tsconfig paths."
+    }
+  },
+  "required": ["project"]
+}

--- a/packages/deno/src/generators/application/schema.json
+++ b/packages/deno/src/generators/application/schema.json
@@ -3,6 +3,7 @@
   "cli": "nx",
   "$id": "Application",
   "title": "Generate an Deno application.",
+  "description": "Setup a new Deno application in the workspace.",
   "type": "object",
   "properties": {
     "name": {

--- a/packages/deno/src/generators/init/generator.ts
+++ b/packages/deno/src/generators/init/generator.ts
@@ -2,13 +2,12 @@ import {
   generateFiles,
   joinPathFragments,
   readNxJson,
-  stripIndents,
   Tree,
   updateJson,
   updateNxJson,
 } from '@nrwl/devkit';
-import { execSync } from 'child_process';
 import * as path from 'path';
+import { assertDenoInstalled } from '../../utils/run-deno';
 
 function addFiles(tree: Tree) {
   if (!tree.exists('import_map.json')) {
@@ -54,25 +53,9 @@ function addDenoPluginToNxJson(tree: Tree) {
 }
 
 export async function initDeno(tree: Tree) {
-  if (!isDenoInstalled()) {
-    console.warn(stripIndents`Unable to find Deno on your system. 
-Deno will need to be installed in order to run targets from @nrwl/deno in this workspace.
-You can learn how to install deno at https://deno.land/manual/getting_started/installation`);
-  }
+  assertDenoInstalled();
   addFiles(tree);
   addDenoPluginToNxJson(tree);
-}
-
-function isDenoInstalled() {
-  try {
-    execSync('deno --version', {
-      encoding: 'utf-8',
-      env: process.env,
-    });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export default initDeno;

--- a/packages/deno/src/generators/init/schema.json
+++ b/packages/deno/src/generators/init/schema.json
@@ -2,7 +2,8 @@
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "$id": "Init",
-  "title": "",
+  "title": "Initilize @nrwl/deno",
+  "description": "Setup the workspace to build Deno projects. Deno must be installed prior to use the @nrwl/deno plugin",
   "type": "object",
   "properties": {},
   "required": []

--- a/packages/deno/src/generators/library/files/node.ts__template__
+++ b/packages/deno/src/generators/library/files/node.ts__template__
@@ -1,0 +1,1 @@
+export * from './src/<%= fileName %>';

--- a/packages/deno/src/generators/library/library.spec.ts
+++ b/packages/deno/src/generators/library/library.spec.ts
@@ -1,0 +1,36 @@
+import { readJson, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { denoLibraryGenerator } from './library';
+
+describe('Deno library', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should add a deno library', async () => {
+    await denoLibraryGenerator(tree, { name: 'my-lib' });
+    expect(tree.exists('libs/my-lib/mod.ts')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/deno.json')).toBeTruthy();
+    expect(readJson(tree, 'import_map.json').imports).toEqual({
+      '@proj/my-lib': './libs/my-lib/mod.ts',
+    });
+  });
+
+  it('should add node entrypoint', async () => {
+    await denoLibraryGenerator(tree, {
+      name: 'my-lib',
+      addNodeEntrypoint: true,
+    });
+    expect(tree.exists('libs/my-lib/node.ts')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/mod.ts')).toBeTruthy();
+    expect(tree.exists('libs/my-lib/deno.json')).toBeTruthy();
+    expect(readJson(tree, 'import_map.json').imports).toEqual({
+      '@proj/my-lib': './libs/my-lib/mod.ts',
+    });
+    expect(readJson(tree, 'tsconfig.base.json').compilerOptions.paths).toEqual({
+      '@proj/my-lib': ['libs/my-lib/node.ts'],
+    });
+  });
+});

--- a/packages/deno/src/generators/library/library.ts
+++ b/packages/deno/src/generators/library/library.ts
@@ -12,7 +12,8 @@ import {
 } from '@nrwl/devkit';
 import { join } from 'path';
 import { initDeno } from '../init/generator';
-import { addImports, addPathToDenoSettings } from '../utils/add-path';
+import { addPathToDenoSettings } from '../utils/add-path';
+import { addImports } from '../utils/imports';
 import { LibraryGeneratorSchema } from './schema';
 
 interface NormalizedSchema extends LibraryGeneratorSchema {

--- a/packages/deno/src/generators/library/schema.d.ts
+++ b/packages/deno/src/generators/library/schema.d.ts
@@ -4,4 +4,6 @@ export interface LibraryGeneratorSchema {
   directory?: string;
   unitTestRunner?: 'deno' | 'none';
   linter?: 'deno' | 'none';
+  addNodeEntrypoint?: boolean;
+  importPath?: string;
 }

--- a/packages/deno/src/generators/library/schema.json
+++ b/packages/deno/src/generators/library/schema.json
@@ -38,6 +38,16 @@
       "description": "Add a linting target for this application.",
       "enum": ["deno", "none"],
       "default": "deno"
+    },
+    "addNodeEntrypoint": {
+      "alias": "node",
+      "type": "boolean",
+      "description": "Add a node entrypoint for this library and add the entrypoint to the root tsconfig paths.",
+      "default": false
+    },
+    "importPath": {
+      "type": "string",
+      "description": "The path to use when importing this library into another library or application"
     }
   },
   "required": ["name"]

--- a/packages/deno/src/generators/preset/generator.ts
+++ b/packages/deno/src/generators/preset/generator.ts
@@ -1,11 +1,10 @@
-import { Tree, writeJson } from '@nrwl/devkit';
-
+import { Tree, updateJson } from '@nrwl/devkit';
 import applicationGenerator from '../application/generator';
 import { PresetGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: PresetGeneratorSchema) {
   const appName = (options.monorepo && options.project) || options.name;
-  const appTask = applicationGenerator(tree, {
+  const appTask = await applicationGenerator(tree, {
     name: appName,
     linter: 'deno',
     unitTestRunner: 'deno',
@@ -13,16 +12,18 @@ export default async function (tree: Tree, options: PresetGeneratorSchema) {
     rootProject: options.rootProject,
   });
 
-  writeJson(tree, 'deno.json', {
-    tasks: {
-      start: 'npx nx serve',
-      lint: 'npx nx lint',
-      test: 'npx nx test',
-      build: 'npx nx build',
-    },
-  });
-
   if (options.rootProject) {
+    updateJson(tree, 'deno.json', (json) => {
+      json['tasks'] = {
+        start: 'npx nx serve',
+        lint: 'npx nx lint',
+        test: 'npx nx test',
+        build: 'npx nx build',
+      };
+
+      return json;
+    });
+
     // Remove these folders so projects will be generated at the root.
     tree.delete('apps');
     tree.delete('libs');

--- a/packages/deno/src/generators/preset/schema.json
+++ b/packages/deno/src/generators/preset/schema.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "$id": "Preset",
-  "title": "Standalone React and rspack preset",
+  "$id": "DenoPreset",
+  "title": "Standalone Deno preset",
+  "description": "Create a Deno project in a standalone Nx Workspace.",
   "type": "object",
   "properties": {
     "name": {

--- a/packages/deno/src/generators/utils/add-path.ts
+++ b/packages/deno/src/generators/utils/add-path.ts
@@ -11,8 +11,10 @@ export function addPathToDenoSettings(tree: Tree, path: string) {
     tree,
     vscodeSettingsPath,
     (json) => {
-      // TODO: when using a standalone deno, we don't need to specify the paths
-      // just enable it for the whole repo.
+      // deno is already enabled for the whole worksapce, don't need to add paths
+      if (json['deno.enable']) {
+        return json;
+      }
       const paths = new Set(json['deno.enablePaths'] || []);
 
       paths.add(path);

--- a/packages/deno/src/generators/utils/add-path.ts
+++ b/packages/deno/src/generators/utils/add-path.ts
@@ -15,6 +15,16 @@ export function addPathToDenoSettings(tree: Tree, path: string) {
       if (json['deno.enable']) {
         return json;
       }
+
+      // we are in a standalone project so we can enable deno for the whole workspace
+      if (path === '.') {
+        json['deno.enable'] = true;
+        // remove the enablePaths property since it will
+        // override the enable property if preset
+        delete json['deno.enablePaths'];
+        return json;
+      }
+
       const paths = new Set(json['deno.enablePaths'] || []);
 
       paths.add(path);

--- a/packages/deno/src/generators/utils/add-path.ts
+++ b/packages/deno/src/generators/utils/add-path.ts
@@ -4,13 +4,15 @@ export function addPathToDenoSettings(tree: Tree, path: string) {
   const vscodeSettingsPath = joinPathFragments('.vscode', 'settings.json');
 
   if (!tree.exists(vscodeSettingsPath)) {
-    tree.write(vscodeSettingsPath, JSON.stringify({ enablePaths: [] }));
+    tree.write(vscodeSettingsPath, '{}');
   }
 
   updateJson(
     tree,
     vscodeSettingsPath,
     (json) => {
+      // TODO: when using a standalone deno, we don't need to specify the paths
+      // just enable it for the whole repo.
       const paths = new Set(json['deno.enablePaths'] || []);
 
       paths.add(path);

--- a/packages/deno/src/generators/utils/imports.spec.ts
+++ b/packages/deno/src/generators/utils/imports.spec.ts
@@ -1,0 +1,183 @@
+import {
+  addProjectConfiguration,
+  ProjectConfiguration,
+  readJson,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import denoAppGenerator from '../application/generator';
+import denoInit from '../init/generator';
+import { addImports, getImportPathForProjectName } from './imports';
+
+describe('import utils', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  describe('add imports', () => {
+    it('should throw error if import_map.json is not found', () => {
+      expect(() =>
+        addImports(tree, {
+          entryPoints: { deno: 'libs/deno-lib/mod.ts' },
+          importPath: '@proj/deno-lib',
+        })
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "import_map.json does not exist in the root of the workspace.
+        This means the workspace has not been initialized for Deno.
+        You can do this by running 'nx g @nrwl/deno:init'"
+      `);
+    });
+
+    it('should add import to import_map.json', async () => {
+      await denoInit(tree);
+      addImports(tree, {
+        entryPoints: { deno: 'libs/deno-lib/mod.ts' },
+        importPath: '@proj/deno-lib',
+      });
+      expect(
+        readJson(tree, 'import_map.json').imports['@proj/deno-lib']
+      ).toEqual('./libs/deno-lib/mod.ts');
+    });
+
+    it('should add node and deno imports', async () => {
+      await denoInit(tree);
+      addImports(tree, {
+        entryPoints: {
+          deno: './libs/deno-lib/mod.ts',
+          node: 'libs/deno-lib/node.ts',
+        },
+        importPath: '@proj/deno-lib',
+      });
+
+      expect(
+        readJson(tree, 'import_map.json').imports['@proj/deno-lib']
+      ).toEqual(`./libs/deno-lib/mod.ts`);
+      expect(
+        readJson(tree, 'tsconfig.base.json').compilerOptions.paths[
+          '@proj/deno-lib'
+        ]
+      ).toEqual(['libs/deno-lib/node.ts']);
+    });
+
+    it('should not add existing deno import', async () => {
+      await denoInit(tree);
+      addImports(tree, {
+        entryPoints: { deno: 'libs/deno-lib/mod.ts' },
+        importPath: '@proj/deno-lib',
+      });
+      expect(
+        readJson(tree, 'import_map.json').imports['@proj/deno-lib']
+      ).toEqual('./libs/deno-lib/mod.ts');
+      expect(() => {
+        addImports(tree, {
+          entryPoints: { deno: 'libs/deno-lib/mod.ts' },
+          importPath: '@proj/deno-lib',
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+        "Import path already exists in import_map.json for @proj/deno-lib.
+        You can specify a different import path using the --import-path option.
+        The value needs to be unique and not already used in the import_map.json file."
+      `);
+    });
+    it('should not add existing tsconfig path', async () => {
+      await denoInit(tree);
+      addImports(tree, {
+        entryPoints: {
+          deno: 'libs/deno-lib/mod.ts',
+          node: 'libs/deno-lib/node.ts',
+        },
+        importPath: '@proj/deno-lib',
+      });
+      expect(
+        readJson(tree, 'import_map.json').imports['@proj/deno-lib']
+      ).toEqual('./libs/deno-lib/mod.ts');
+      updateJson(tree, 'import_map.json', (json) => {
+        delete json.imports['@proj/deno-lib'];
+        return json;
+      });
+      expect(() => {
+        addImports(tree, {
+          entryPoints: {
+            deno: 'libs/deno-lib/mod.ts',
+            node: 'libs/deno-lib/node.ts',
+          },
+
+          importPath: '@proj/deno-lib',
+        });
+      }).toThrowErrorMatchingInlineSnapshot(`
+        "Import path already exists in tsconfig.base.json for @proj/deno-lib.
+        You can specify a different import path using the --import-path option.
+        The value needs to be unique and not already used in the tsconfig.base.json file."
+      `);
+    });
+  });
+
+  describe('read tsconfig paths', () => {
+    it('should get tsconfig path for a project', async () => {
+      const pc = await addNodeAndDenoProjects(tree, 'proj');
+      const actual = getImportPathForProjectName(tree, pc);
+      expect(actual).toEqual({
+        importAlias: '@proj/proj-node',
+        importPath: 'libs/proj-node/src/index.ts',
+      });
+    });
+
+    it('should throw error if no tsconfig.base.json', async () => {
+      const pc = await addNodeAndDenoProjects(tree, 'proj');
+      tree.delete('tsconfig.base.json');
+      expect(() => getImportPathForProjectName(tree, pc))
+        .toThrowErrorMatchingInlineSnapshot(`
+        "Could not find a root tsconfig.json or tsconfig.base.json to import paths from.
+        A root tsconfig is required in order to use an existing import path from another project."
+      `);
+    });
+
+    it('should throw error if no path was found', async () => {
+      const pc = await addNodeAndDenoProjects(tree, 'proj');
+      updateJson(tree, 'tsconfig.base.json', (json) => {
+        delete json.compilerOptions.paths[`@proj/proj-node`];
+        return json;
+      });
+      expect(() =>
+        getImportPathForProjectName(tree, pc)
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Unable to find any import path in tsconfig.base.json for project proj-node"`
+      );
+    });
+  });
+});
+
+async function addNodeAndDenoProjects(tree: Tree, name: string) {
+  await denoAppGenerator(tree, { name: `${name}-deno` });
+  const pc: ProjectConfiguration = {
+    name: `${name}-node`,
+    root: `libs/${name}-node`,
+    sourceRoot: `libs/${name}-node/src`,
+    projectType: 'library',
+    targets: {
+      build: {
+        executor: '@nrwl/esbuild:esbuild',
+        options: {},
+      },
+    },
+  };
+  tree.write(`libs/${name}-node/src/index.ts`, '');
+  addProjectConfiguration(tree, `${name}-node`, pc);
+  updateJson(tree, 'tsconfig.base.json', (json) => {
+    json.compilerOptions.paths[`@proj/abc`] = [`libs/abc/src/index.ts`];
+    json.compilerOptions.paths[`@proj/${name}-123`] = [
+      '*',
+      `libs/${name}-node-wrong/src/index.ts`,
+    ];
+    json.compilerOptions.paths[`@proj/blah`] = [`libs/not-it/src/index.ts`];
+    json.compilerOptions.paths[`@proj/${name}-node`] = [
+      `libs/${name}-node/src/index.ts`,
+    ];
+    return json;
+  });
+
+  // TODO(caleb): calling readProjectConfiguration causes tests to just error, with no error message
+  return pc;
+}

--- a/packages/deno/src/generators/utils/imports.ts
+++ b/packages/deno/src/generators/utils/imports.ts
@@ -1,0 +1,115 @@
+import {
+  joinPathFragments,
+  ProjectConfiguration,
+  readJson,
+  stripIndents,
+  Tree,
+  updateJson,
+} from '@nrwl/devkit';
+import { getRootTsConfigPathInTree, TsConfigPaths } from './ts-config';
+
+interface ImportOptions {
+  importPath: string;
+  entryPoints: {
+    /**
+     * relative paths need to be prefixed with './' for deno to treat as a local file import
+     */
+    deno: string;
+    node?: string;
+  };
+}
+
+export function addImports(tree: Tree, options: ImportOptions) {
+  if (!tree.exists('import_map.json')) {
+    throw new Error(stripIndents`import_map.json does not exist in the root of the workspace.
+      This means the workspace has not been initialized for Deno.
+      You can do this by running 'nx g @nrwl/deno:init'`);
+  }
+
+  updateJson(tree, 'import_map.json', (json) => {
+    json.imports = json.imports || {};
+    if (json.imports[options.importPath]) {
+      throw new Error(
+        `Import path already exists in import_map.json for ${options.importPath}.
+You can specify a different import path using the --import-path option.
+The value needs to be unique and not already used in the import_map.json file.`
+      );
+    }
+    json.imports[options.importPath] = options.entryPoints.deno.startsWith('./')
+      ? options.entryPoints.deno
+      : `./${options.entryPoints.deno}`;
+    return json;
+  });
+
+  if (options.entryPoints.node) {
+    const rootTsConfig = getRootTsConfigPathInTree(tree);
+    if (!tree.exists(rootTsConfig)) {
+      throw new Error(stripIndents`Could not find root tsconfig to add the import path to.
+        This means a root level tsconfig.json or tsconfig.base.json file is not preset but is expected when using the --add-node-entrypoint flag`);
+    }
+    updateJson(tree, rootTsConfig, (json) => {
+      json.compilerOptions.paths = json.compilerOptions?.paths || {};
+      if (json.compilerOptions.paths[options.importPath]) {
+        throw new Error(stripIndents`Import path already exists in ${rootTsConfig} for ${options.importPath}.
+You can specify a different import path using the --import-path option.
+The value needs to be unique and not already used in the ${rootTsConfig} file.`);
+      }
+
+      json.compilerOptions.paths[options.importPath] = [
+        options.entryPoints.node.startsWith('./')
+          ? options.entryPoints.node.slice(2)
+          : options.entryPoints.node,
+      ];
+
+      return json;
+    });
+  }
+}
+
+export function getImportPathForProjectName(
+  tree: Tree,
+  projectConfig: ProjectConfiguration
+) {
+  const rootTsconfigPath = getRootTsConfigPathInTree(tree);
+  if (!tree.exists(rootTsconfigPath)) {
+    throw new Error(stripIndents`Could not find a root tsconfig.json or tsconfig.base.json to import paths from.
+A root tsconfig is required in order to use an existing import path from another project.`);
+  }
+
+  const tsconfig = readJson<TsConfigPaths>(tree, rootTsconfigPath);
+  if (!tsconfig?.compilerOptions?.paths) {
+    throw new Error(`No paths found in ${rootTsconfigPath}`);
+  }
+
+  const paths = Object.entries(
+    (tsconfig.compilerOptions.paths = tsconfig.compilerOptions?.paths || {})
+  );
+
+  for (const [importAlias, aliasedPath] of paths) {
+    const foundImport = aliasedPath.find((p) => {
+      const resolvedPath =
+        !tsconfig.compilerOptions?.baseUrl ||
+        tsconfig.compilerOptions?.baseUrl === '.'
+          ? p
+          : joinPathFragments(tsconfig.compilerOptions.baseUrl, p);
+
+      const normalizedRoot = projectConfig.root.endsWith('/')
+        ? projectConfig.root
+        : `${projectConfig.root}/`;
+
+      return resolvedPath.includes(normalizedRoot);
+    });
+
+    if (foundImport) {
+      return {
+        // import maps don't use * for deep imports, instead it's a /
+        importAlias: importAlias.replace('/*', '/'),
+        importPath: foundImport.replace('/*', '/'),
+      };
+    }
+  }
+
+  throw new Error(
+    `Unable to find any import path in ${rootTsconfigPath} for project ${projectConfig.name}`
+  );
+}

--- a/packages/deno/src/generators/utils/ts-config.ts
+++ b/packages/deno/src/generators/utils/ts-config.ts
@@ -1,0 +1,15 @@
+import { Tree } from '@nrwl/devkit';
+
+// TODO(caleb): switch to @nrwl/js version once we update and make it a dep
+export function getRootTsConfigPathInTree(tree: Tree): string | null {
+  for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
+    if (tree.exists(path)) {
+      return path;
+    }
+  }
+
+  return 'tsconfig.base.json';
+}
+export interface TsConfigPaths {
+  compilerOptions: { paths?: Record<string, string[]>; baseUrl?: string };
+}

--- a/packages/deno/src/graph/process-graph.ts
+++ b/packages/deno/src/graph/process-graph.ts
@@ -12,7 +12,7 @@ import {
   findProjectForPath,
 } from 'nx/src/project-graph/utils/find-project-for-path';
 import { extname, join, relative } from 'path';
-import { runDeno } from '../utils/run-deno';
+import { assertDenoInstalled, runDeno } from '../utils/run-deno';
 
 const ALLOWED_FILE_EXT = [
   '.ts',
@@ -29,6 +29,8 @@ export async function processProjectGraph(
   graph: ProjectGraph,
   context: ProjectGraphProcessorContext
 ): Promise<ProjectGraph> {
+  assertDenoInstalled();
+
   const builder = new ProjectGraphBuilder(graph);
   const projectRootMap = createProjectRootMappings(graph.nodes);
   const processes: Array<() => Promise<void>> = [];

--- a/packages/deno/src/utils/run-deno.ts
+++ b/packages/deno/src/utils/run-deno.ts
@@ -1,5 +1,5 @@
-import { workspaceRoot } from '@nrwl/devkit';
-import { spawn } from 'child_process';
+import { stripIndents, workspaceRoot } from '@nrwl/devkit';
+import { execSync, spawn } from 'child_process';
 
 export interface DenoExecOptions {
   /**
@@ -24,4 +24,19 @@ export function runDeno(args: any[], options: DenoExecOptions = {}) {
     // TODO: make sure this doesn't popup cmd on windows?
     windowsHide: true,
   });
+}
+
+export function assertDenoInstalled() {
+  try {
+    execSync('deno --version', {
+      encoding: 'utf-8',
+      env: process.env,
+    });
+  } catch (err) {
+    throw new Error(stripIndents`Unable to find Deno on your system. 
+Deno will need to be installed in order to run targets from @nrwl/deno in this workspace.
+You can learn how to install deno at https://deno.land/manual/getting_started/installation
+If you've already installed Deno, then make sure it's avaiable in your PATH.
+You might need to quit and restart your terminal.`);
+  }
 }


### PR DESCRIPTION
- check for deno before running and provide helpful error when not found
- add --add-node-entrypoint option to lib generator to create a node.ts for dual runtime libs
- add --import-path option to lib generator to override the generated import path
- add add-import generator to take tsconfig path and add to import_map.json


TODO:
- [x] write unit tests
- [x] write e2e tests