### PR TITLE
feat(deno): add support for standalone as the default setup

### DIFF
--- a/e2e/deno-e2e/project.json
+++ b/e2e/deno-e2e/project.json
@@ -8,7 +8,9 @@
       "executor": "@nrwl/nx-plugin:e2e",
       "options": {
         "target": "deno:build",
-        "jestConfig": "e2e/deno-e2e/jest.config.ts"
+        "jestConfig": "e2e/deno-e2e/jest.config.ts",
+        "bail": true,
+        "maxWorkers": 1
       }
     }
   },

--- a/e2e/deno-e2e/tests/deno-integrated.spec.ts
+++ b/e2e/deno-e2e/tests/deno-integrated.spec.ts
@@ -17,7 +17,7 @@ import {
   workspaceFileExists,
 } from './utils';
 
-describe('Deno', () => {
+describe('Deno integrated monorepo', () => {
   const appName = uniq('deno-app');
   const libName = uniq('deno-lib');
   // Setting up individual workspaces per

--- a/e2e/deno-e2e/tests/deno-standalone.spec.ts
+++ b/e2e/deno-e2e/tests/deno-standalone.spec.ts
@@ -1,0 +1,291 @@
+import { names } from '@nrwl/devkit';
+import {
+  ensureNxProject,
+  readJson,
+  runNxCommandAsync,
+  tmpProjPath,
+  uniq,
+  updateFile,
+} from '@nrwl/nx-plugin/testing';
+import { unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import {
+  killPort,
+  promisifiedTreeKill,
+  runCommandUntil,
+  workspaceDirectoryExists,
+  workspaceFileExists,
+} from './utils';
+
+describe('Deno standalone app', () => {
+  const appName = uniq('deno-app');
+  const libName = uniq('deno-lib');
+  // Setting up individual workspaces per
+  // test can cause e2e runs to take a long time.
+  // For this reason, we recommend each suite only
+  // consumes 1 workspace. The tests should each operate
+  // on a unique project in the workspace, such that they
+  // are not dependant on one another.
+  beforeAll(() => {
+    ensureNxProject('@nrwl/deno', 'dist/packages/deno');
+  });
+
+  afterAll(() => {
+    // `nx reset` kills the daemon, and performs
+    // some work which can help clean up e2e leftovers
+    runNxCommandAsync('reset');
+  });
+
+  describe('application', () => {
+    it('should create deno app', async () => {
+      await runNxCommandAsync(`generate @nrwl/deno:preset ${appName}`);
+      expect(readJson(`import_map.json`)).toEqual({ imports: {} });
+      expect(readJson(`deno.json`)).toEqual({
+        importMap: 'import_map.json',
+      });
+      expect(workspaceFileExists(`src/main.ts`)).toBeTruthy();
+      expect(workspaceFileExists(`src/handler.test.ts`)).toBeTruthy();
+      expect(workspaceFileExists(`src/handler.ts`)).toBeTruthy();
+    }, 120_000);
+
+    it('should build deno app', async () => {
+      const result = await runNxCommandAsync(`build ${appName}`);
+      expect(result.stdout).toContain(
+        `Successfully ran target build for project ${appName}`
+      );
+      expect(workspaceFileExists(`dist/${appName}/main.js`)).toBeTruthy();
+    }, 120_000);
+
+    it('should serve deno app', async () => {
+      const p = await runCommandUntil(`serve ${appName}`, (output) => {
+        return output.includes(`Listening on`);
+      });
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
+      await killPort(8000);
+    }, 120_000);
+
+    it('should test deno app', async () => {
+      const result = await runNxCommandAsync(`test ${appName}`);
+      expect(result.stdout).toContain(
+        `Successfully ran target test for project ${appName}`
+      );
+      expect(workspaceDirectoryExists(`coverage/${appName}`)).toBeTruthy();
+    }, 120_000);
+    it('should test deno app w/options', async () => {
+      const badTestFilePath = join(tmpProjPath(), 'src', 'file.test.ts');
+      writeFileSync(
+        badTestFilePath,
+        `import { assertEquals } from 'https://deno.land/std@0.172.0/testing/asserts.ts';
+
+Deno.test('Another File', async () => {
+  const num: string = 1;
+  assertEquals(Deno.env.get('DENO_JOBS'), '2');
+});
+`
+      );
+      const result = await runNxCommandAsync(
+        `test ${appName} -p=2 --check=none`
+      );
+      expect(result.stdout).toContain(
+        `Successfully ran target test for project ${appName}`
+      );
+      expect(workspaceDirectoryExists(`coverage/${appName}`)).toBeTruthy();
+      await expect(async () => {
+        await runNxCommandAsync(`test ${appName} -p=2`);
+      }).rejects.toThrow();
+      unlinkSync(badTestFilePath);
+    }, 120_000);
+
+    it('should lint deno app', async () => {
+      const result = await runNxCommandAsync(`lint ${appName}`);
+      expect(result.stdout).toContain(
+        `Successfully ran target lint for project ${appName}`
+      );
+    }, 120_000);
+
+    describe('--directory', () => {
+      const nestedAppName = uniq('deno-app');
+      it('should create app in the specified directory', async () => {
+        await runNxCommandAsync(
+          `generate @nrwl/deno:app ${nestedAppName} --directory nested`
+        );
+        expect(
+          workspaceFileExists(`nested/${nestedAppName}/src/main.ts`)
+        ).toBeTruthy();
+      }, 120_000);
+      it('should build deno app', async () => {
+        const result = await runNxCommandAsync(`build nested-${nestedAppName}`);
+        expect(result.stdout).toContain(
+          `Successfully ran target build for project nested-${nestedAppName}`
+        );
+        expect(
+          workspaceFileExists(`dist/nested/${nestedAppName}/main.js`)
+        ).toBeTruthy();
+      }, 120_000);
+
+      it('should serve deno app', async () => {
+        const p = await runCommandUntil(
+          `serve nested-${nestedAppName}`,
+          (output) => {
+            return output.includes(`Listening on`);
+          }
+        );
+        await promisifiedTreeKill(p.pid, 'SIGKILL');
+        await killPort(8000);
+      }, 120_000);
+
+      it('should test deno app', async () => {
+        const result = await runNxCommandAsync(`test nested-${nestedAppName}`);
+        expect(result.stdout).toContain(
+          `Successfully ran target test for project nested-${nestedAppName}`
+        );
+        expect(
+          workspaceDirectoryExists(`coverage/nested/${nestedAppName}`)
+        ).toBeTruthy();
+      }, 120_000);
+
+      it('should lint deno app', async () => {
+        const result = await runNxCommandAsync(`lint nested-${nestedAppName}`);
+        expect(result.stdout).toContain(
+          `Successfully ran target lint for project nested-${nestedAppName}`
+        );
+      }, 120_000);
+    });
+
+    it('should add tags to app project', async () => {
+      await runNxCommandAsync(
+        `generate @nrwl/deno:app ${appName}-tagged --tags scope:deno,type:app`
+      );
+      const project = readJson(`${appName}-tagged/project.json`);
+      expect(project.tags).toEqual(['scope:deno', 'type:app']);
+    }, 120_000);
+  });
+
+  describe('library', () => {
+    it('should create deno lib', async () => {
+      await runNxCommandAsync(`generate @nrwl/deno:lib ${libName}`);
+      expect(readJson(`import_map.json`)).toEqual({
+        imports: {
+          [`@proj/${libName}`]: `./${libName}/mod.ts`,
+        },
+      });
+      expect(readJson(`${libName}/deno.json`)).toEqual({
+        importMap: '../import_map.json',
+      });
+      expect(workspaceFileExists(`${libName}/mod.ts`)).toBeTruthy();
+      expect(
+        workspaceFileExists(`${libName}/src/${libName}.test.ts`)
+      ).toBeTruthy();
+      expect(workspaceFileExists(`${libName}/src/${libName}.ts`)).toBeTruthy();
+    }, 120_000);
+
+    it('should test deno lib', async () => {
+      const result = await runNxCommandAsync(`test ${libName}`);
+      expect(result.stdout).toContain(
+        `Successfully ran target test for project ${libName}`
+      );
+      expect(workspaceDirectoryExists(`coverage/${libName}`)).toBeTruthy();
+    }, 120_000);
+
+    it('should test deno lib w/options', async () => {
+      const badTestFilePath = join(
+        tmpProjPath(),
+        libName,
+        'src',
+        'file.test.ts'
+      );
+      writeFileSync(
+        badTestFilePath,
+        `import { assertEquals } from 'https://deno.land/std@0.172.0/testing/asserts.ts';
+
+Deno.test('Another File', async () => {
+  const num: string = 1;
+  assertEquals(Deno.env.get('DENO_JOBS'), '2');
+});
+`
+      );
+      const result = await runNxCommandAsync(
+        `test ${libName} -p=2 --check=none`
+      );
+      expect(result.stdout).toContain(
+        `Successfully ran target test for project ${libName}`
+      );
+      expect(workspaceDirectoryExists(`coverage/${libName}`)).toBeTruthy();
+      await expect(async () => {
+        await runNxCommandAsync(`test ${libName} -p=2`);
+      }).rejects.toThrow();
+      unlinkSync(badTestFilePath);
+    }, 120_000);
+
+    it('should lint deno lib', async () => {
+      const result = await runNxCommandAsync(`lint ${libName}`);
+      expect(result.stdout).toContain(
+        `Successfully ran target lint for project ${libName}`
+      );
+    }, 120_000);
+
+    describe('--directory', () => {
+      const nestedLibName = uniq('deno-lib');
+      it('should create lib in the specified directory', async () => {
+        await runNxCommandAsync(
+          `generate @nrwl/deno:lib ${nestedLibName} --directory nested`
+        );
+        expect(readJson(`import_map.json`)).toEqual({
+          imports: {
+            [`@proj/${libName}`]: `./${libName}/mod.ts`,
+            [`@proj/nested-${nestedLibName}`]: `./nested/${nestedLibName}/mod.ts`,
+          },
+        });
+        expect(
+          workspaceFileExists(`nested/${nestedLibName}/mod.ts`)
+        ).toBeTruthy();
+        expect(
+          workspaceFileExists(
+            `nested/${nestedLibName}/src/${nestedLibName}.test.ts`
+          )
+        ).toBeTruthy();
+        expect(
+          workspaceFileExists(`nested/${nestedLibName}/src/${nestedLibName}.ts`)
+        ).toBeTruthy();
+      }, 120_000);
+
+      it('should test deno lib', async () => {
+        const result = await runNxCommandAsync(`test nested-${nestedLibName}`);
+        expect(result.stdout).toContain(
+          `Successfully ran target test for project nested-${nestedLibName}`
+        );
+        expect(
+          workspaceDirectoryExists(`coverage/nested/${nestedLibName}`)
+        ).toBeTruthy();
+      }, 120_000);
+      it('should lint deno lib', async () => {
+        const result = await runNxCommandAsync(`lint nested-${nestedLibName}`);
+        expect(result.stdout).toContain(
+          `Successfully ran target lint for project nested-${nestedLibName}`
+        );
+      }, 120_000);
+    });
+    it('should add tags to lib project', async () => {
+      await runNxCommandAsync(
+        `generate @nrwl/deno:lib ${libName}-tagged --tags scope:deno,type:lib`
+      );
+      const project = readJson(`${libName}-tagged/project.json`);
+      expect(project.tags).toEqual(['scope:deno', 'type:lib']);
+    }, 120_000);
+
+    it('should be able to use import alias of lib in app', async () => {
+      const fnName = names(libName).propertyName;
+      updateFile(
+        `src/main.ts`,
+        `import { ${fnName} } from '@proj/${libName}'
+
+console.log(${fnName}())`
+      );
+
+      const p = await runCommandUntil(`serve ${appName}`, (output) => {
+        return output.includes(libName);
+      });
+      await promisifiedTreeKill(p.pid, 'SIGKILL');
+    }, 120_000);
+  });
+});

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -5,18 +5,39 @@
 Create a new Nx worksapce if you don't already have one.
 
 ```shell
-npx create-nx-workspace@latest --preset=apps
+npx create-nx-workspace@latest deno-demo --preset=@nrwl/deno:preset
 ```
 
-`cd` into the new workspace you created.
-
-Install the Deno plugin
+Now, you can go into the `deno-demo` folder and start development.
 
 ```shell
-npm i -DE @nrwl/deno@latest
+cd deno-demo
+deno task start
+```
+
+You can also run lint, test, and build scripts for the project.
+
+```shell
+deno task lint
+deno task test
+deno task build
+```
+
+**Note:** Change `deno-demo` to any project name you want.
+
+## Existing workspaces
+
+You can add Deno to any existing Nx workspace.
+
+First, install the plugin:
+
+```bash
+npm install -DE @nrwl/deno@latest
 ```
 
 ## Create a new Deno App
+
+You can create additional Deno apps
 
 ```shell
 npx nx g @nrwl/deno:app
@@ -37,7 +58,7 @@ Building/Bundling is an optional step in Deno so you don't have to build when us
 ## Create a new Deno Library
 
 ```shell
-npx nx g @nrwl/deno:app
+npx nx g @nrwl/deno:lib
 ```
 
 Deno libraies only come with lint/test targets to run.

--- a/packages/deno/generators.json
+++ b/packages/deno/generators.json
@@ -7,18 +7,27 @@
       "factory": "./src/generators/application/generator",
       "schema": "./src/generators/application/schema.json",
       "description": "Create a new Deno application",
-      "aliases": ["app"]
+      "aliases": [
+        "app"
+      ]
     },
     "library": {
       "factory": "./src/generators/library/library",
       "schema": "./src/generators/library/schema.json",
       "description": "Create a new Deno library",
-      "aliases": ["lib"]
+      "aliases": [
+        "lib"
+      ]
     },
     "init": {
       "factory": "./src/generators/init/generator",
       "schema": "./src/generators/init/schema.json",
       "description": "Intialize configurations for Deno"
+    },
+    "preset": {
+      "factory": "./src/generators/preset/generator",
+      "schema": "./src/generators/preset/schema.json",
+      "description": "preset generator"
     }
   }
 }

--- a/packages/deno/src/generators/application/schema.d.ts
+++ b/packages/deno/src/generators/application/schema.d.ts
@@ -5,4 +5,6 @@ export interface ApplicationGeneratorSchema {
   unitTestRunner?: 'deno' | 'none';
   linter?: 'deno' | 'none';
   withWatch?: boolean;
+  monorepo?: boolean;
+  rootProject?: boolean;
 }

--- a/packages/deno/src/generators/application/schema.json
+++ b/packages/deno/src/generators/application/schema.json
@@ -42,6 +42,16 @@
       "type": "boolean",
       "description": "Default the project to watch for file changes for the 'serve' target. For projects that do not need watch capability (eg: CLI projects), use --with-watch=false",
       "default": true
+    },
+    "monorepo": {
+      "type": "boolean",
+      "description": "Creates an integrated monorepo.",
+      "aliases": ["integrated"],
+      "x-priority": "internal"
+    },
+    "rootProject": {
+      "type": "boolean",
+      "x-priority": "internal"
     }
   },
   "required": ["name"]

--- a/packages/deno/src/generators/preset/generator.ts
+++ b/packages/deno/src/generators/preset/generator.ts
@@ -1,0 +1,32 @@
+import { Tree, writeJson } from '@nrwl/devkit';
+
+import applicationGenerator from '../application/generator';
+import { PresetGeneratorSchema } from './schema';
+
+export default async function (tree: Tree, options: PresetGeneratorSchema) {
+  const appName = (options.monorepo && options.project) || options.name;
+  const appTask = applicationGenerator(tree, {
+    name: appName,
+    linter: 'deno',
+    unitTestRunner: 'deno',
+    withWatch: true,
+    rootProject: options.rootProject,
+  });
+
+  writeJson(tree, 'deno.json', {
+    tasks: {
+      start: 'npx nx serve',
+      lint: 'npx nx lint',
+      test: 'npx nx test',
+      build: 'npx nx build',
+    },
+  });
+
+  if (options.rootProject) {
+    // Remove these folders so projects will be generated at the root.
+    tree.delete('apps');
+    tree.delete('libs');
+  }
+
+  return appTask;
+}

--- a/packages/deno/src/generators/preset/schema.d.ts
+++ b/packages/deno/src/generators/preset/schema.d.ts
@@ -1,0 +1,6 @@
+export interface PresetGeneratorSchema {
+  name: string;
+  project?: string;
+  rootProject?: boolean;
+  monorepo?: boolean;
+}

--- a/packages/deno/src/generators/preset/schema.json
+++ b/packages/deno/src/generators/preset/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "Preset",
+  "title": "Standalone React and rspack preset",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the workspace. Used as the app name when for standalone projects.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-priority": "important"
+    },
+    "project": {
+      "type": "string",
+      "description": "Name of the app when using --monorepo."
+    },
+    "monorepo": {
+      "type": "boolean",
+      "description": "Creates an integrated monorepo.",
+      "default": false,
+      "aliases": ["integrated"]
+    },
+    "rootProject": {
+      "type": "boolean",
+      "x-priority": "internal",
+      "default": true
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
This PR adds `@nrwl/deno:preset` generator for use with CNW and support standalone projects.

```
npx create-nx-workspace@latest --preset=@nrwl/deno

# For monorepos 
npx create-nx-workspace@latest --preset=@nrwl/deno --monorepo
```