### PR TITLE
feat: read OTP from env

### DIFF
--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -1,6 +1,6 @@
+import * as chalk from 'chalk';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
-import * as chalk from 'chalk';
 
 let [, , name, version, tag] = process.argv;
 const validVersion = /^\d+\.\d+\.\d(-\w+\.\d+)?/;
@@ -18,4 +18,7 @@ const json = JSON.parse(readFileSync(`package.json`).toString());
 json.version = version;
 writeFileSync(`package.json`, JSON.stringify(json, null, 2));
 
-execSync(`npm publish --access public --tag ${tag}`);
+// USAGE example: NPM_OTP=381781 node tools/scripts/publish.mjs remix 15.8.5 latest
+execSync(
+  `npm publish --access public --tag ${tag} --otp ${process.env.NPM_OTP}`
+);


### PR DESCRIPTION
Just so that we can use this script with OTP enabled. It is not the most elegant way possible but does the job. We should probably look into having a similar release script as we have in the main repo (maybe just copy it over here)