### PR TITLE
fix(rspack): use built-in minifier instead

### DIFF
--- a/packages/rspack/src/utils/with-nx.ts
+++ b/packages/rspack/src/utils/with-nx.ts
@@ -64,10 +64,7 @@ export function withNx(_opts = {}) {
       plugins: config.plugins ?? [],
       resolve: {
         alias,
-        // This is not working it seems.
-        //plugins: [new TsconfigPathsPlugin({
-        //  configFile: path.resolve(__dirname, 'tsconfig.app.json')
-        //})]
+        tsConfigPath: path.resolve(__dirname, 'tsconfig.app.json'),
       },
       infrastructureLogging: {
         debug: false,
@@ -99,17 +96,9 @@ export function withNx(_opts = {}) {
     };
 
     if (options.optimization) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const minifyPlugin = require('@rspack/plugin-minify');
       updated.optimization = {
         ...config.optimization,
         minimize: true,
-        minimizer: [
-          ...(config.optimization?.minimizer || []),
-          new minifyPlugin({
-            minifier: 'terser',
-          }),
-        ],
       };
     }
 


### PR DESCRIPTION
Rspack will use its built-in swc minifier when `optimization.minimize` is `true` and no `optimization.minimizer` is set, which is much faster than js plugin (`@rspack/plugin-minify`).

And `resolve.plugins` is not supported for now, but there is a `resolve.tsConfigPath` can do something similar.