### PR TITLE
feat(rspack): update and pin rspack to 0.1.0

### DIFF
--- a/packages/rspack/src/utils/versions.ts
+++ b/packages/rspack/src/utils/versions.ts
@@ -1,8 +1,8 @@
-export const rspackCoreVersion = '^0.0.23';
-export const rspackDevServerVersion = '^0.0.23';
+export const rspackCoreVersion = '0.1.0';
+export const rspackDevServerVersion = '0.1.0';
 
-export const rspackPluginMinifyVersion = '^0.0.23';
-export const rspackLessLoaderVersion = '^0.0.23';
+export const rspackPluginMinifyVersion = '0.1.0';
+export const rspackLessLoaderVersion = '0.1.0';
 
 export const reactVersion = '~18.2.0';
 export const reactDomVersion = '~18.2.0';


### PR DESCRIPTION
Updating to `0.1.0` as the stable version we're releasing with today.