### PR TITLE
feat(deno): add @nrwl/deno:emit executor that replaces the deprecated bundle command

### DIFF
--- a/packages/deno/executors.json
+++ b/packages/deno/executors.json
@@ -4,7 +4,13 @@
     "bundle": {
       "implementation": "./src/executors/bundle/bundle.impl",
       "schema": "./src/executors/bundle/schema.json",
-      "description": "Output a single JavaScript file with all dependencies."
+      "description": "Output a single JavaScript file with all dependencies.",
+      "x-deprecated": "Use @nrwl/deno:emit instead. This will be removed in when `deno bundle` is removed."
+    },
+    "emit": {
+      "implementation": "./src/executors/emit/emit.impl",
+      "schema": "./src/executors/emit/schema.json",
+      "description": "Bundle or transpile to a JavaScript file."
     },
     "run": {
       "implementation": "./src/executors/run/run.impl",

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -5,6 +5,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
+    "chalk": "^4.1.0",
     "fs-extra": "^11.0.0",
     "@nrwl/devkit": "^15.7.0"
   }

--- a/packages/deno/src/executors/emit/emit.impl.ts
+++ b/packages/deno/src/executors/emit/emit.impl.ts
@@ -1,0 +1,118 @@
+import { ExecutorContext, logger, stripIndents } from '@nrwl/devkit';
+import * as chalk from 'chalk';
+import { dirname, join, resolve } from 'path';
+import { BuildExecutorSchema } from './schema';
+
+import { ensureDirSync, unlinkSync, writeFileSync } from 'fs-extra';
+import { processCommonArgs } from '../../utils/arg-utils';
+import { assertDenoInstalled, runDeno } from '../../utils/run-deno';
+
+export async function denoEmitExecutor(
+  options: BuildExecutorSchema,
+  context: ExecutorContext
+) {
+  assertDenoInstalled();
+  const opts = normalizeOptions(options, context);
+  const args = createArgs(opts, context);
+
+  logger.info(
+    `Using ${chalk.bold('deno_emit')} to build ${chalk.bold(
+      opts.main
+    )} (https://deno.land/x/emit)`
+  );
+
+  return new Promise((resolve) => {
+    const runningDenoProcess = runDeno(args);
+
+    runningDenoProcess.on('exit', (code) => {
+      resolve({ success: code === 0 });
+    });
+  });
+}
+
+function normalizeOptions(
+  options: BuildExecutorSchema,
+  context: ExecutorContext
+) {
+  // TODO: we might need to normalize paths here to make sure it works on windows?
+  if (!options.denoConfig) {
+    throw new Error('denoConfig is required');
+  }
+  if (!options.main) {
+    throw new Error('main is required');
+  }
+  if (!options.outputFile) {
+    options.outputFile = join('dist', options.main);
+  }
+
+  ensureDirSync(resolve(context.root, dirname(options.outputFile)));
+
+  options.bundle ??= true;
+
+  return options;
+}
+
+function createArgs(options: BuildExecutorSchema, context: ExecutorContext) {
+  const tmpBundleFile = createTempEmitFile(options, context);
+  const args = ['run', '--allow-all'];
+
+  args.push(`--config=${options.denoConfig}`);
+
+  args.push(...processCommonArgs(options));
+
+  args.push(tmpBundleFile);
+
+  return args;
+}
+
+function createTempEmitFile(
+  options: BuildExecutorSchema,
+  context: ExecutorContext
+) {
+  const project = context.projectGraph.nodes[context.projectName];
+  const tmpBundleFile = join(
+    context.root,
+    'tmp',
+    project.data.root,
+    'deno-emit.ts'
+  );
+  const mainFilePath = join(context.root, options.main);
+  const outputFilePath = join(context.root, options.outputFile);
+
+  const content = options.bundle
+    ? stripIndents`
+      import { bundle } from "https://deno.land/x/emit/mod.ts";
+      const result = await bundle(
+        new URL('${mainFilePath}', import.meta.url),
+      );
+
+      const { code } = result;
+      Deno.writeTextFile('${outputFilePath}', code);
+    `
+    : stripIndents`
+      import { emit } from "https://deno.land/x/emit/mod.ts";
+      const url = new URL('${join(mainFilePath)}', import.meta.url);
+      const result = await emit(url);
+
+      const code = result[url.href];
+      Deno.writeTextFile('${outputFilePath}', code);
+    `;
+
+  process.on('exit', () => cleanupTmpBundleFile(tmpBundleFile));
+  ensureDirSync(dirname(tmpBundleFile));
+  writeFileSync(tmpBundleFile, content);
+
+  return tmpBundleFile;
+}
+
+function cleanupTmpBundleFile(tmpFile: string) {
+  try {
+    if (tmpFile) {
+      unlinkSync(tmpFile);
+    }
+  } catch (e) {
+    // nothing
+  }
+}
+
+export default denoEmitExecutor;

--- a/packages/deno/src/executors/emit/schema.d.ts
+++ b/packages/deno/src/executors/emit/schema.d.ts
@@ -1,0 +1,6 @@
+export interface BuildExecutorSchema {
+  denoConfig: string;
+  main: string;
+  outputFile: string;
+  bundle?: boolean;
+}

--- a/packages/deno/src/executors/emit/schema.json
+++ b/packages/deno/src/executors/emit/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "version": 2,
+  "cli": "nx",
+  "title": "Deno Emit Executor",
+  "description": "Output a single JavaScript file with all dependencies",
+  "type": "object",
+  "properties": {
+    "denoConfig": {
+      "type": "string",
+      "description": "Path to the Deno configuration file."
+    },
+    "main": {
+      "type": "string",
+      "description": "The entry point for your Deno application."
+    },
+    "outputFile": {
+      "type": "string",
+      "description": "The destination of the emitted JavaScript file."
+    },
+    "bundle": {
+      "type": "boolean",
+      "description": "Bundle all imports into a single JavaScript file.",
+      "default": true
+    }
+  },
+  "required": ["main", "outputFile", "denoConfig"]
+}

--- a/packages/deno/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/deno/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`Deno App Generator integrated should create --platform=netlify integrat
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nrwl/deno:bundle",
+      "executor": "@nrwl/deno:emit",
       "options": {
         "denoConfig": "apps/my-app-netlify/deno.json",
         "main": "apps/my-app-netlify/src/main.ts",
@@ -90,7 +90,7 @@ exports[`Deno App Generator integrated should make an integrated deno app 1`] = 
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nrwl/deno:bundle",
+      "executor": "@nrwl/deno:emit",
       "options": {
         "denoConfig": "apps/my-app/deno.json",
         "main": "apps/my-app/src/main.ts",
@@ -136,7 +136,7 @@ exports[`Deno App Generator integrated should make an oak api with --framework=o
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nrwl/deno:bundle",
+      "executor": "@nrwl/deno:emit",
       "options": {
         "denoConfig": "apps/my-oak-api/deno.json",
         "main": "apps/my-oak-api/src/main.ts",
@@ -217,7 +217,7 @@ exports[`Deno App Generator standalone should create --platform=netlify app 1`] 
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nrwl/deno:bundle",
+      "executor": "@nrwl/deno:emit",
       "options": {
         "denoConfig": "deno.json",
         "main": "src/main.ts",
@@ -297,7 +297,7 @@ exports[`Deno App Generator standalone should make a deno app 1`] = `
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nrwl/deno:bundle",
+      "executor": "@nrwl/deno:emit",
       "options": {
         "denoConfig": "deno.json",
         "main": "src/main.ts",
@@ -343,7 +343,7 @@ exports[`Deno App Generator standalone should make an oak api with --framework=o
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nrwl/deno:bundle",
+      "executor": "@nrwl/deno:emit",
       "options": {
         "denoConfig": "deno.json",
         "main": "src/main.ts",

--- a/packages/deno/src/generators/application/lib.ts
+++ b/packages/deno/src/generators/application/lib.ts
@@ -81,7 +81,7 @@ export function addProjectConfig(tree: Tree, opts: DenoAppNormalizedSchema) {
   );
   const targets: ProjectConfiguration['targets'] = {
     build: {
-      executor: '@nrwl/deno:bundle',
+      executor: '@nrwl/deno:emit',
       outputs: [
         joinPathFragments(
           'dist',
@@ -226,7 +226,7 @@ export function applyNetlifyAppConfig(
   # https://docs.netlify.com/edge-functions/api/#import-maps
   deno_import_map = "import_map.json"
 
-# Read more about declaring edge functions: 
+# Read more about declaring edge functions:
 # https://docs.netlify.com/edge-functions/declarations/#declare-edge-functions-in-netlify-toml
 [[edge_functions]]
   # this is the name of the file in the ${srcDir}.
@@ -240,7 +240,7 @@ export function applyNetlifyAppConfig(
   tree.write(
     `${srcDir}/app.ts`,
     `/**
-* Netlify Edge Function overview: 
+* Netlify Edge Function overview:
 * https://docs.netlify.com/edge-functions/overview/
 **/
 

--- a/packages/deno/src/generators/setup-serverless/lib/deno-deploy.ts
+++ b/packages/deno/src/generators/setup-serverless/lib/deno-deploy.ts
@@ -18,7 +18,6 @@ export function addDenoDeployConfig(
 
 function addDeployTarget(tree: Tree, projectConfig: ProjectConfiguration) {
   const main =
-    // TODO(caleb): when @nrwl/deno:bundle is removed this value will always be undefined unless replaced
     projectConfig.targets?.build?.options?.main ||
     joinPathFragments(projectConfig.sourceRoot, 'main.ts');
 

--- a/packages/deno/src/generators/utils/testing/deno-app.ts
+++ b/packages/deno/src/generators/utils/testing/deno-app.ts
@@ -10,7 +10,7 @@ export function createDenoAppForTesting(
     root: opts.projectRoot,
     targets: {
       build: {
-        executor: '@nrwl/deno:bundle',
+        executor: '@nrwl/deno:emit',
         options: {
           main: joinPathFragments(opts.projectRoot, 'src/main.ts'),
           outputFile: joinPathFragments(


### PR DESCRIPTION
Since `deno bundle` is deprecated, add a new `@nrwl/deno:emit` executor that wraps [`deno_emit`](https://github.com/denoland/deno_emit). This is a more basic version of bundle that does not support options such as `--watch`.

Update app generator to use `@nrwl/deno:emit` instead, and add a deprecation message to `@nrwl/deno:bundle`.