### PR TITLE
fix(rspack): add dependency to ajv-keywords that match the version used by rspack

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -22,6 +22,7 @@
     "@nrwl/linter": "^15.8.1",
     "@nrwl/devkit": "^15.8.1",
     "ajv": "^8.12.0",
+    "ajv-keywords": "5.1.0",
     "less-loader": "11.1.0",
     "sass-loader": "^12.2.0",
     "stylus-loader": "^7.1.0"


### PR DESCRIPTION
Otherwise there may be an error when using the wrong version of `ajv-keywords`.