### PR TITLE
feat(netlify): add @nrwl/netlify package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@nrwl/linter": "15.8.5",
     "@nrwl/nx-plugin": "15.8.5",
     "@nrwl/react": "15.8.5",
+    "@nrwl/node": "15.8.5",
     "@nrwl/workspace": "15.8.5",
     "@swc-node/register": "^1.4.2",
     "@types/fs-extra": "^11.0.1",
@@ -63,6 +64,6 @@
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",
-    "typescript": "4.9.5"
+    "typescript": "~4.9.5"
   }
 }

--- a/packages/netlify/.eslintrc.json
+++ b/packages/netlify/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["./package.json", "./generators.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nrwl/nx/nx-plugin-checks": "error"
+      }
+    }
+  ]
+}

--- a/packages/netlify/generators.json
+++ b/packages/netlify/generators.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "name": "netlify",
+  "version": "0.0.1",
+  "generators": {
+    "serverless": {
+      "factory": "./src/generators/serverless/serverless",
+      "schema": "./src/generators/serverless/schema.json",
+      "description": "Serverless project generator"
+    },
+    "setup-serverless": {
+      "factory": "./src/generators/setup-serverless/setup-serverless",
+      "schema": "./src/generators/setup-serverless/schema.json",
+      "description": "Setup serverless generator"
+    },
+    "preset": {
+      "factory": "./src/generators/preset/preset",
+      "schema": "./src/generators/preset/schema.json",
+      "description": "Nx Netlify Serverless preset generator",
+      "hidden": true
+    }
+  }
+}

--- a/packages/netlify/index.ts
+++ b/packages/netlify/index.ts
@@ -1,0 +1,2 @@
+export { serverlessGenerator } from './src/generators/serverless/serverless';
+export { setupServerlessGenerator } from './src/generators/setup-serverless/setup-serverless';

--- a/packages/netlify/jest.config.ts
+++ b/packages/netlify/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'netlify',
+  preset: '../../jest.preset.js',
+  globals: {},
+  transform: {
+    '^.+\\.[tj]s$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/netlify',
+};

--- a/packages/netlify/package.json
+++ b/packages/netlify/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nrwl/netlify",
+  "version": "0.0.1",
+  "main": "src/index.js",
+  "generators": "./generators.json",
+  "dependencies": {
+    "@nrwl/devkit": "*",
+    "@nrwl/node": "*",
+    "@nrwl/linter": "*"
+  }
+}

--- a/packages/netlify/project.json
+++ b/packages/netlify/project.json
@@ -1,0 +1,65 @@
+{
+  "name": "netlify",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/netlify/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/netlify",
+        "main": "packages/netlify/src/index.ts",
+        "tsConfig": "packages/netlify/tsconfig.lib.json",
+        "assets": [
+          "packages/netlify/*.md",
+          {
+            "input": "./packages/netlify/src",
+            "glob": "**/!(*.ts)",
+            "output": "./src"
+          },
+          {
+            "input": "./packages/netlify/src",
+            "glob": "**/*.d.ts",
+            "output": "./src"
+          },
+          {
+            "input": "./packages/netlify",
+            "glob": "generators.json",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "packages/netlify/**/*.ts",
+          "packages/netlify/generators.json",
+          "packages/netlify/package.json"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/netlify/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": false,
+        "commands": [
+          "nx build netlify",
+          "node tools/scripts/publish.mjs netlify {args.ver} {args.tag}"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/netlify/src/generators/preset/preset.ts
+++ b/packages/netlify/src/generators/preset/preset.ts
@@ -1,0 +1,22 @@
+import { Tree, updateJson } from '@nrwl/devkit';
+import { serverlessGenerator } from '../serverless/serverless';
+import { PresetGeneratorSchema } from './schema';
+
+export default async function (tree: Tree, options: PresetGeneratorSchema) {
+  const appTask = serverlessGenerator(tree, options);
+
+  updateJson(tree, 'package.json', (json) => {
+    json.scripts ??= {};
+    json.scripts.build ??= 'npx nx build';
+    json.scripts.lint ??= 'npx nx lint';
+    json.scripts.test ??= 'npx nx test';
+    json.scripts.dev ??= 'npx nx dev';
+    json.scripts.deploy ??= 'npx nx deploy';
+    return json;
+  });
+
+    tree.delete('apps');
+    tree.delete('libs');
+
+  return appTask;
+}

--- a/packages/netlify/src/generators/preset/schema.d.ts
+++ b/packages/netlify/src/generators/preset/schema.d.ts
@@ -1,0 +1,14 @@
+export interface PresetGeneratorSchema {
+  name: string;
+  unitTestRunner?: 'none' | 'jest';
+  directory?: string;
+  tags?: string;
+  lintTarget?: string;
+  buildTarget?: string;
+  deployTarget?: string;
+  site?: string;
+}
+
+export interface NormalizedSchema extends PresetGeneratorSchema {
+  appProjectRoot: string;
+}

--- a/packages/netlify/src/generators/preset/schema.json
+++ b/packages/netlify/src/generators/preset/schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "SchematicsNxServerlessPreset",
+  "title": "Nx Serverless Preset",
+  "description": "Preset for Nx Serverless",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the application.",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the node application?",
+      "x-priority": "important"
+    },
+    "directory": {
+      "description": "The directory of the new application.",
+      "type": "string",
+      "x-priority": "important"
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for unit tests.",
+      "default": "jest"
+    },
+    "buildTarget": {
+      "description": "The name of the build target",
+      "type": "string",
+      "default": "build"
+    },
+    "deployTarget": {
+      "description": "The name of the deploy target",
+      "type": "string",
+      "default": "deploy"
+    },
+    "lintTarget": {
+      "description": "The name of the lint target",
+      "type": "string",
+      "default": "lint"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the application (used for linting)."
+    },
+    "site": {
+      "description": "The site where the serverless function will be deployed",
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}

--- a/packages/netlify/src/generators/serverless/schema.d.ts
+++ b/packages/netlify/src/generators/serverless/schema.d.ts
@@ -1,0 +1,14 @@
+import { Linter } from '@nrwl/linter';
+export interface Schema {
+  name: string;
+  skipFormat?: boolean;
+  skipPackageJson?: boolean;
+  directory?: string;
+  unitTestRunner?: 'jest' | 'none';
+  linter?: Linter;
+  tags?: string;
+  lintTarget?: string;
+  buildTarget?: string;
+  deployTarget?: string;
+  site?: string;
+}

--- a/packages/netlify/src/generators/serverless/schema.json
+++ b/packages/netlify/src/generators/serverless/schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "SchematicsNxServerlessApp",
+  "title": "Nx Netlify Serverless Application Options Schema",
+  "description": "Nx Netlify Serverless Application Options Schema.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the application.",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the node application?",
+      "x-priority": "important"
+    },
+    "directory": {
+      "description": "The directory of the new application.",
+      "type": "string",
+      "x-priority": "important"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`.",
+      "x-priority": "internal"
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint"],
+      "default": "eslint"
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["jest", "none"],
+      "description": "Test runner to use for unit tests.",
+      "default": "jest"
+    },
+    "buildTarget": {
+      "description": "The name of the build target",
+      "type": "string",
+      "default": "build"
+    },
+    "deployTarget": {
+      "description": "The name of the deploy target",
+      "type": "string",
+      "default": "deploy"
+    },
+    "lintTarget": {
+      "description": "The name of the lint target",
+      "type": "string",
+      "default": "lint"
+    },
+    "tags": {
+      "type": "string",
+      "description": "Add tags to the application (used for linting)."
+    },
+    "site": {
+      "description": "The site where the serverless function will be deployed",
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}

--- a/packages/netlify/src/generators/serverless/serverless.ts
+++ b/packages/netlify/src/generators/serverless/serverless.ts
@@ -1,0 +1,50 @@
+import {
+  extractLayoutDirectory,
+  GeneratorCallback,
+  names,
+  Tree,
+} from '@nrwl/devkit';
+import { Linter } from '@nrwl/linter';
+import { applicationGenerator } from '@nrwl/node';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import setupServerlessGenerator from '../setup-serverless/setup-serverless';
+import { Schema } from './schema';
+
+function normalizeOptions(options: Schema): Schema {
+  const { projectDirectory } = extractLayoutDirectory(options.directory);
+  const appDirectory = projectDirectory
+    ? `${names(projectDirectory).fileName}/${names(options.name).fileName}`
+    : names(options.name).fileName;
+
+  const appProjectName = appDirectory.replace(new RegExp('/', 'g'), '-');
+  return {
+    ...options,
+    name: names(appProjectName).fileName,
+    lintTarget: options.lintTarget ?? 'lint',
+    linter: options.linter ?? Linter.EsLint,
+    unitTestRunner: options.unitTestRunner ?? 'jest',
+  };
+}
+
+export async function serverlessGenerator(tree: Tree, schema: Schema) {
+  const options = normalizeOptions(schema);
+  const tasks: GeneratorCallback[] = [];
+
+  const init = await applicationGenerator(tree, {
+    ...options,
+    framework: 'none',
+    e2eTestRunner: 'none',
+    rootProject: true,
+  });
+
+  tasks.push(init);
+
+  const addServerlessTask = await setupServerlessGenerator(tree, {
+    ...options,
+    project: options.name,
+  });
+
+  tasks.push(addServerlessTask);
+
+  return runTasksInSerial(...tasks);
+}

--- a/packages/netlify/src/generators/serverless/severless.spec.ts
+++ b/packages/netlify/src/generators/serverless/severless.spec.ts
@@ -1,0 +1,30 @@
+import { readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
+import { serverlessGenerator } from './serverless';
+describe('serverless', () => {
+  let tree: Tree;
+
+  beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
+
+  it('should be an empty node project', async () => {
+    await serverlessGenerator(tree, {
+      name: 'api',
+    });
+
+    const project = readProjectConfiguration(tree, 'api');
+    expect(tree.exists('netlify.toml'));
+    expect(tree.exists('src/main.ts'));
+    expect(tree.exists('functions/hello/hello.ts'));
+    expect(project.targets).toEqual(
+      expect.objectContaining({
+        dev: {
+          command: 'npx netlify dev'
+        },
+        deploy: {
+          dependsOn: ['lint'],
+          command: 'npx netlify deploy --prod-if-unlocked',
+        },
+      })
+    );
+  });
+});

--- a/packages/netlify/src/generators/setup-serverless/files/netlify.toml__tmpl__
+++ b/packages/netlify/src/generators/setup-serverless/files/netlify.toml__tmpl__
@@ -1,0 +1,40 @@
+[build]
+  # Directory to change to before starting a build.
+  # This is where we will look for package.json/.nvmrc/etc.
+  # If not set, defaults to the root directory.
+  publish = "<%= outputPath %>"
+
+[functions]
+  # Directory with serverless functions, including background
+  # functions, to deploy. This is relative to the base directory
+  # if one has been set, or the root directory if
+  # a base hasn’t been set.
+  directory = "src/functions/"
+
+  # Specifies `esbuild` for functions bundling, esbuild is the default for TS
+  # node_bundler = "esbuild"
+
+  # Flags "package-1" as an external node module for all functions
+  # list of Node.js modules that are copied to the bundled artifact without adjusting their source or references during the bundling process; 
+  # only applies when node_bundler is set to esbuild. 
+  # This property helps handle dependencies that can’t be inlined, such as modules with native add-ons.
+  # external_node_modules = ["package-1"]
+
+  # Includes all Markdown files inside the "files/" directory.
+  # lets you specify additional files or directories and reference them dynamically in function code. 
+  # staticly referenced files are automatically included in the bundle
+  # You can use * to match any character or prefix an entry with ! to exclude files. 
+  # Paths are relative to the base directory.
+  # included_files = ["files/*.md"]
+
+  [functions."hello*"]
+  # Apply settings to any functions with a name beginning with "hello"
+ 
+  # Functions matching this pattern have both "package-1" and "package-2" 
+  # as external modules, because modules from this object
+  # are concatenated with any from the top-level object.
+  # external_node_modules = ["package-2"]
+
+  # Includes all Markdown files previously defined in the
+  # top-level object, except for "post-1.md".
+  # included_files = ["!files/post-1.md"]

--- a/packages/netlify/src/generators/setup-serverless/files/src/functions/hello/hello.ts__tmpl__
+++ b/packages/netlify/src/generators/setup-serverless/files/src/functions/hello/hello.ts__tmpl__
@@ -1,0 +1,10 @@
+import { Handler } from '@netlify/functions'
+
+export const handler: Handler = async(event, context) => {
+    return {
+        statusCode: 200,
+        body: JSON.stringify({
+            message: `Hello, world!`
+        }),
+    };
+},

--- a/packages/netlify/src/generators/setup-serverless/schema.d.ts
+++ b/packages/netlify/src/generators/setup-serverless/schema.d.ts
@@ -1,0 +1,10 @@
+export interface SetupServerlessFunctionOptions {
+  project?: string;
+  buildTarget?: string;
+  lintTarget?: string;
+  deployTarget?: string;
+  devTarget?: string;
+  skipFormat?: boolean;
+  skipPackageJson?: boolean;
+  site?: string;
+}

--- a/packages/netlify/src/generators/setup-serverless/schema.json
+++ b/packages/netlify/src/generators/setup-serverless/schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "SchematicsNxSetupServerless",
+  "title": "Nx Node Setup Serverless Function Schema",
+  "description": "Nx Node Setup Serverless Function Schema.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "description": "The name of the project",
+      "$default": {
+        "$source": "projectName"
+      },
+      "type": "string",
+      "x-prompt": "What project would you like to add a serverless functions to?",
+      "x-priority": "important"
+    },
+    "buildTarget": {
+      "description": "The name of the build target",
+      "type": "string",
+      "default": "build"
+    },
+    "deployTarget": {
+      "description": "The name of the deploy target",
+      "type": "string",
+      "default": "deploy"
+    },
+    "devTarget": {
+      "description": "The name of the dev target",
+      "type": "string",
+      "default": "dev"
+    },
+    "lintTarget": {
+      "description": "The name of the lint target",
+      "type": "string",
+      "default": "lint"
+    },
+    "skipFormat": {
+      "description": "Skips formatting the workspace after the generator completes.",
+      "type": "boolean",
+      "default": false,
+      "x-priority": "internal"
+    },
+    "skipPackageJson": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not add dependencies to `package.json`.",
+      "x-priority": "internal"
+    },
+    "site": {
+      "description": "The site where the serverless function will be deployed",
+      "type": "string"
+    }
+  }
+}

--- a/packages/netlify/src/generators/setup-serverless/setup-serverless.spec.ts
+++ b/packages/netlify/src/generators/setup-serverless/setup-serverless.spec.ts
@@ -1,0 +1,66 @@
+import { readProjectConfiguration, Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { applicationGenerator } from '@nrwl/node';
+import { setupServerlessGenerator } from './setup-serverless';
+describe('setupServerlessGenerator', () => {
+  let tree: Tree;
+
+  beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
+
+  describe('integrated', () => {
+    it('should create a netlify platform specific asset which is used to deploy', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework: 'express',
+        e2eTestRunner: 'none',
+        docker: false,
+      });
+      await setupServerlessGenerator(tree, {
+        project: 'api',
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+      expect(tree.exists('netlify.toml'));
+      expect(project.targets).toEqual(
+        expect.objectContaining({
+          dev: {
+            command: 'npx netlify dev',
+          },
+          deploy: {
+            dependsOn: ['lint'],
+            command: 'npx netlify deploy --prod-if-unlocked',
+          },
+        })
+      );
+    });
+  });
+
+  describe('standalone', () => {
+    it('should create a netlify platform specific asset which is used to deploy', async () => {
+      await applicationGenerator(tree, {
+        name: 'api',
+        framework: 'express',
+        rootProject: true,
+        docker: true,
+      });
+
+      await setupServerlessGenerator(tree, {
+        project: 'api',
+      });
+
+      const project = readProjectConfiguration(tree, 'api');
+      expect(tree.exists('netlify.toml'));
+      expect(project.targets).toEqual(
+        expect.objectContaining({
+          dev: {
+            command: 'npx netlify dev',
+          },
+          deploy: {
+            dependsOn: ['lint'],
+            command: 'npx netlify deploy --prod-if-unlocked',
+          },
+        })
+      );
+    });
+  });
+});

--- a/packages/netlify/src/generators/setup-serverless/setup-serverless.ts
+++ b/packages/netlify/src/generators/setup-serverless/setup-serverless.ts
@@ -1,0 +1,118 @@
+import {
+  addDependenciesToPackageJson,
+  convertNxGenerator,
+  formatFiles,
+  generateFiles,
+  GeneratorCallback,
+  joinPathFragments,
+  logger,
+  names,
+  readNxJson,
+  readProjectConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import {
+  netlifyCliVersion,
+  netlifyFunctionVersion,
+} from '../../../utils/versions';
+import { SetupServerlessFunctionOptions } from './schema';
+
+
+function normalizeOptions(
+  tree: Tree,
+  setupOptions: SetupServerlessFunctionOptions
+) {
+  const project = setupOptions.project ?? readNxJson(tree).defaultProject;
+  const siteName = names(project).fileName;
+  return {
+    ...setupOptions,
+    project,
+    site: setupOptions.site ?? siteName,
+    lintTarget: setupOptions.lintTarget ?? 'lint',
+    devTarget: setupOptions.devTarget ?? 'dev',
+    buildTarget: setupOptions.buildTarget ?? 'build',
+    deployTarget: setupOptions.deployTarget ?? 'deploy',
+  };
+}
+
+function addServerlessFiles(
+  tree: Tree,
+  options: SetupServerlessFunctionOptions
+) {
+  const project = readProjectConfiguration(tree, options.project);
+  if (!options.project || !options.deployTarget) {
+    return;
+  }
+
+  if (tree.exists(joinPathFragments(project.root, 'netlify.toml'))) {
+    logger.info(
+      `Skipping setup since a netlify.toml already exists inside ${project.root}`
+    );
+  }
+
+  const outputPath =
+    project.targets[`${options.buildTarget}`]?.options.outputPath;
+  generateFiles(tree, joinPathFragments(__dirname, `./files`), project.root, {
+    tmpl: '',
+    app: project.sourceRoot,
+    outputPath,
+  });
+}
+
+function updateProjectConfig(
+  tree: Tree,
+  options: SetupServerlessFunctionOptions
+) {
+  const projectConfig = readProjectConfiguration(tree, options.project);
+
+  if (projectConfig) {
+    projectConfig.targets[`${options.buildTarget}`].options.bundle = true;
+    projectConfig.targets[`${options.devTarget}`] = {
+      command: 'npx netlify dev',
+    };
+
+    projectConfig.targets[`${options.deployTarget}`] = {
+      dependsOn: [`${options.lintTarget}`],
+      command: 'npx netlify deploy --prod-if-unlocked',
+    };
+
+    updateProjectConfiguration(tree, options.project, projectConfig);
+  }
+}
+
+export async function setupServerlessGenerator(
+  tree: Tree,
+  setupOptions: SetupServerlessFunctionOptions
+) {
+  const tasks: GeneratorCallback[] = [];
+  const options = normalizeOptions(tree, setupOptions);
+
+  addServerlessFiles(tree, options);
+  updateProjectConfig(tree, options);
+
+  if (!options.skipPackageJson) {
+    tasks.push(
+      addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+          '@netlify/functions': netlifyFunctionVersion,
+          'netlify-cli': netlifyCliVersion,
+        }
+      )
+    );
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+
+  return runTasksInSerial(...tasks);
+}
+
+export default setupServerlessGenerator;
+export const setupServerlessSchematic = convertNxGenerator(
+  setupServerlessGenerator
+);

--- a/packages/netlify/src/index.ts
+++ b/packages/netlify/src/index.ts
@@ -1,0 +1,2 @@
+export * from './generators/serverless/serverless';
+export * from './generators/setup-serverless/setup-serverless';

--- a/packages/netlify/tsconfig.json
+++ b/packages/netlify/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/netlify/tsconfig.lib.json
+++ b/packages/netlify/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/netlify/tsconfig.spec.json
+++ b/packages/netlify/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/packages/netlify/utils/versions.ts
+++ b/packages/netlify/utils/versions.ts
@@ -1,0 +1,2 @@
+export const netlifyFunctionVersion = '^1.4.0';
+export const netlifyCliVersion = '13.2.1';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "baseUrl": ".",
     "paths": {
       "@nrwl/deno": ["packages/deno/src/index.ts"],
+      "@nrwl/netlify": ["packages/netlify/index.ts"],
       "@nrwl/rspack": ["packages/rspack/src/index.ts"],
       "nx-remix/nx-remix": ["packages/nx-remix/src/index.ts"]
     }


### PR DESCRIPTION
This PR provides an opt-in to add serverless configuration to any project or create a new project that has a server-less configuration

**New projects**

- Generate a serverless application
- Run `npx nx generate @nrwl/netlify:serverless api --platform=netlify`
- Run `npx nx run api:deploy`

**Existing Projects**

- Run `npx nx generate @nrwl/netlify:setup-serverless --project=api --platform=netlify`
- Run `npx nx run api:deploy`

This should 

1. Create a server-less application (_new projects only_) with the `netlify.toml` deploy file
2. Add the `functions/hello.ts` server-less function
3. Install `netlify-cli` which is used to deploy your node server
4. Add a deploy target to Netlify