### PR TITLE
feat(deno): only support standalone projects using the custom preset

### DIFF
--- a/packages/deno/src/generators/preset/generator.ts
+++ b/packages/deno/src/generators/preset/generator.ts
@@ -3,31 +3,28 @@ import applicationGenerator from '../application/application';
 import { PresetGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: PresetGeneratorSchema) {
-  const appName = (options.monorepo && options.project) || options.name;
   const appTask = await applicationGenerator(tree, {
-    name: appName,
+    name: options.name,
     linter: 'deno',
     unitTestRunner: 'deno',
     withWatch: true,
-    rootProject: options.rootProject,
+    rootProject: true,
   });
 
-  if (options.rootProject) {
-    updateJson(tree, 'deno.json', (json) => {
-      json['tasks'] = {
-        start: 'npx nx serve',
-        lint: 'npx nx lint',
-        test: 'npx nx test',
-        build: 'npx nx build',
-      };
+  updateJson(tree, 'deno.json', (json) => {
+    json['tasks'] = {
+      start: 'npx nx serve',
+      lint: 'npx nx lint',
+      test: 'npx nx test',
+      build: 'npx nx build',
+    };
 
-      return json;
-    });
+    return json;
+  });
 
-    // Remove these folders so projects will be generated at the root.
-    tree.delete('apps');
-    tree.delete('libs');
-  }
+  // Remove these folders so projects will be generated at the root.
+  tree.delete('apps');
+  tree.delete('libs');
 
   return appTask;
 }

--- a/packages/deno/src/generators/preset/schema.d.ts
+++ b/packages/deno/src/generators/preset/schema.d.ts
@@ -1,6 +1,3 @@
 export interface PresetGeneratorSchema {
   name: string;
-  project?: string;
-  rootProject?: boolean;
-  monorepo?: boolean;
 }

--- a/packages/deno/src/generators/preset/schema.json
+++ b/packages/deno/src/generators/preset/schema.json
@@ -14,21 +14,6 @@
         "index": 0
       },
       "x-priority": "important"
-    },
-    "project": {
-      "type": "string",
-      "description": "Name of the app when using --monorepo."
-    },
-    "monorepo": {
-      "type": "boolean",
-      "description": "Creates an integrated monorepo.",
-      "default": false,
-      "aliases": ["integrated"]
-    },
-    "rootProject": {
-      "type": "boolean",
-      "x-priority": "internal",
-      "default": true
     }
   },
   "required": ["name"]


### PR DESCRIPTION
This PR removes monorepo setup for `@nrwl/deno:preset` generator, so all new workspaces using the custom preset will be standalone.

Users that want to add a Deno app to their workspace can install `@nrwl/deno` and call the app generator.