### PR TITLE
fix(rspack): set externals for target node

### DIFF
--- a/packages/rspack/src/generators/configuration/configuration.ts
+++ b/packages/rspack/src/generators/configuration/configuration.ts
@@ -86,7 +86,7 @@ function addBuildTarget(tree: Tree, options: ConfigurationSchema) {
           },
           production: {
             mode: 'production',
-            optimization: true,
+            optimization: options.target === 'web' ? true : undefined,
             sourceMap: false,
           },
         },


### PR DESCRIPTION
This should fix the `nest` issue.

Still needs:

```
  config.externals = {
    '@nestjs/common': '"@nestjs/common"',
    '@nestjs/core': '"@nestjs/core"',
  };
```

in `rspack.config.js`