### PR TITLE
feat(rspack): configuration generator better ux

### DIFF
--- a/packages/rspack/src/generators/application/application.ts
+++ b/packages/rspack/src/generators/application/application.ts
@@ -67,9 +67,10 @@ export default async function (
     project: options.name,
     devServer: true,
     tsConfig: joinPathFragments(options.appProjectRoot, 'tsconfig.app.json'),
-    uiFramework: 'react',
+    framework: 'react',
     target: 'web',
     main: joinPathFragments(options.appProjectRoot, 'src/main.tsx'),
+    newProject: true,
   });
   tasks.push(projectTask);
 

--- a/packages/rspack/src/generators/configuration/configuration.ts
+++ b/packages/rspack/src/generators/configuration/configuration.ts
@@ -1,13 +1,16 @@
+import { formatFiles, readProjectConfiguration, Tree } from '@nrwl/devkit';
 import {
-  formatFiles,
-  joinPathFragments,
-  readProjectConfiguration,
-  TargetConfiguration,
-  Tree,
-  updateProjectConfiguration,
-} from '@nrwl/devkit';
-import { tsquery } from '@phenomnomnominal/tsquery';
-import { RspackExecutorSchema } from '../../executors/rspack/schema';
+  addOrChangeBuildTarget,
+  addOrChangeServeTarget,
+  deleteWebpackConfig,
+  determineFrameworkAndTarget,
+  findExistingTargetsInProject,
+  handleUnknownExecutors,
+  handleUnsupportedUserProvidedTargets,
+  TargetFlags,
+  UserProvidedTargetName,
+  writeRspackConfigFile,
+} from '../../utils/generator-utils';
 import rspackInitGenerator from '../init/init';
 import { ConfigurationSchema } from './schema';
 
@@ -16,250 +19,116 @@ export async function configurationGenerator(
   options: ConfigurationSchema
 ) {
   const task = await rspackInitGenerator(tree, options);
-  const { targets, root } = readProjectConfiguration(tree, options.project);
-  const foundStylePreprocessorOptions: { includePaths?: string[] } | undefined =
-    targets?.build?.options?.stylePreprocessorOptions;
+  const { targets, root, projectType } = readProjectConfiguration(
+    tree,
+    options.project
+  );
 
-  const { target, uiFramework } = determineFrameworkAndTarget(
+  const { target, framework } = determineFrameworkAndTarget(
     tree,
     options,
     root,
     targets
   );
-  options.uiFramework = uiFramework;
+  options.framework = framework;
   options.target = target;
 
-  addBuildTarget(tree, options);
-  if (options.uiFramework !== 'none' || options.devServer) {
-    addServeTarget(tree, options);
+  let foundStylePreprocessorOptions: { includePaths?: string[] } | undefined;
+
+  let buildTargetName = 'build';
+  let serveTargetName = 'serve';
+
+  /**
+   * This is for when we are converting an existing project
+   * to use the vite executors.
+   */
+  let projectAlreadyHasRspackTargets: TargetFlags = {};
+
+  if (!options.newProject) {
+    const userProvidedTargetName: UserProvidedTargetName = {
+      build: options.buildTarget,
+      serve: options.serveTarget,
+    };
+
+    const {
+      validFoundTargetName,
+      projectContainsUnsupportedExecutor,
+      userProvidedTargetIsUnsupported,
+      alreadyHasNxRspackTargets,
+    } = findExistingTargetsInProject(targets, userProvidedTargetName);
+    projectAlreadyHasRspackTargets = alreadyHasNxRspackTargets;
+
+    if (
+      alreadyHasNxRspackTargets.build &&
+      (alreadyHasNxRspackTargets.serve ||
+        projectType === 'library' ||
+        options.framework === 'nest')
+    ) {
+      throw new Error(
+        `The project ${options.project} is already configured to use the @nrwl/rspack executors.
+        Please try a different project, or remove the existing targets 
+        and re-run this generator to reset the existing Rspack Configuration.
+        `
+      );
+    }
+
+    if (!validFoundTargetName.build && projectContainsUnsupportedExecutor) {
+      throw new Error(
+        `The project ${options.project} cannot be converted to use the @nrwl/rspack executors.`
+      );
+    }
+
+    if (
+      !projectContainsUnsupportedExecutor &&
+      !validFoundTargetName.build &&
+      !validFoundTargetName.serve
+    ) {
+      await handleUnknownExecutors(options.project);
+    }
+
+    await handleUnsupportedUserProvidedTargets(
+      userProvidedTargetIsUnsupported,
+      userProvidedTargetName,
+      validFoundTargetName,
+      options.framework
+    );
+
+    /**
+     * Once the user is at this stage, then they can go ahead and convert.
+     */
+
+    buildTargetName = validFoundTargetName.build ?? buildTargetName;
+    serveTargetName = validFoundTargetName.serve ?? serveTargetName;
+
+    // Not needed atm
+    // if (projectType === 'application' && options.target !== 'node') {
+    //   moveAndEditIndexHtml(tree, options, buildTargetName);
+    // }
+
+    foundStylePreprocessorOptions =
+      targets?.[buildTargetName]?.options?.stylePreprocessorOptions;
+
+    deleteWebpackConfig(
+      tree,
+      root,
+      targets?.[buildTargetName]?.options?.webpackConfig
+    );
+  }
+
+  if (!projectAlreadyHasRspackTargets.build) {
+    addOrChangeBuildTarget(tree, options, buildTargetName);
+  }
+
+  if (
+    (options.framework !== 'none' || options.devServer) &&
+    options.framework !== 'nest' &&
+    !projectAlreadyHasRspackTargets.serve
+  ) {
+    addOrChangeServeTarget(tree, options, serveTargetName);
   }
   writeRspackConfigFile(tree, options, foundStylePreprocessorOptions);
   await formatFiles(tree);
   return task;
-}
-
-function determineFrameworkAndTarget(
-  tree: Tree,
-  options: ConfigurationSchema,
-  projectRoot: string,
-  targets: {
-    [targetName: string]: TargetConfiguration<any>;
-  }
-): { target: 'node' | 'web'; uiFramework?: 'none' | 'react' | 'web' } {
-  // First try to infer if the target is node
-  if (options.target !== 'node') {
-    // Try to infer from jest config if the env is node
-    let jestConfigPath: string;
-    if (
-      targets?.test?.executor !== '@nrwl/jest:jest' &&
-      targets?.test?.options?.jestConfig
-    ) {
-      jestConfigPath = targets?.test?.options?.jestConfig;
-    } else {
-      jestConfigPath = joinPathFragments(projectRoot, 'jest.config.ts');
-    }
-
-    if (!tree.exists(jestConfigPath)) {
-      return { target: options.target, uiFramework: options.uiFramework };
-    }
-    const appFileContent = tree.read(jestConfigPath, 'utf-8');
-    const file = tsquery.ast(appFileContent);
-    // find testEnvironment: 'node' in jest config
-    const testEnvironment = tsquery(
-      file,
-      `PropertyAssignment:has(Identifier[name="testEnvironment"]) > StringLiteral[value="node"]`
-    );
-    if (testEnvironment.length > 0) {
-      return { target: 'node', uiFramework: options.uiFramework };
-    }
-  }
-
-  if (options.uiFramework !== 'react' && options.target === 'web') {
-    // Look if React is used in the project
-    let tsConfigPath = joinPathFragments(projectRoot, 'tsconfig.json');
-    if (!tree.exists(tsConfigPath)) {
-      tsConfigPath = determineTsConfig(tree, options);
-    }
-    const tsConfig = JSON.parse(tree.read(tsConfigPath).toString());
-    if (tsConfig?.compilerOptions?.jsx?.includes('react')) {
-      return { target: 'web', uiFramework: 'react' };
-    } else {
-      return { target: options.target, uiFramework: options.uiFramework };
-    }
-  }
-}
-
-function determineMain(tree: Tree, options: ConfigurationSchema) {
-  if (options.main) return options.main;
-
-  const project = readProjectConfiguration(tree, options.project);
-
-  const mainTsx = joinPathFragments(project.root, 'src/main.tsx');
-  if (tree.exists(mainTsx)) return mainTsx;
-
-  return joinPathFragments(project.root, 'src/main.ts');
-}
-
-function determineTsConfig(tree: Tree, options: ConfigurationSchema) {
-  if (options.tsConfig) return options.tsConfig;
-
-  const project = readProjectConfiguration(tree, options.project);
-
-  const appJson = joinPathFragments(project.root, 'tsconfig.app.json');
-  if (tree.exists(appJson)) return appJson;
-
-  const libJson = joinPathFragments(project.root, 'tsconfig.lib.json');
-  if (tree.exists(libJson)) return libJson;
-
-  return joinPathFragments(project.root, 'tsconfig.json');
-}
-
-function addBuildTarget(tree: Tree, options: ConfigurationSchema) {
-  const project = readProjectConfiguration(tree, options.project);
-
-  const assets = [];
-  if (
-    options.target === 'web' &&
-    tree.exists(joinPathFragments(project.root, 'src/favicon.ico'))
-  ) {
-    assets.push(joinPathFragments(project.root, 'src/favicon.ico'));
-  }
-  if (tree.exists(joinPathFragments(project.root, 'src/assets'))) {
-    assets.push(joinPathFragments(project.root, 'src/assets'));
-  }
-
-  const buildOptions: RspackExecutorSchema = {
-    target: options.target ?? 'web',
-    outputPath: joinPathFragments(
-      'dist',
-      // If standalone project then use the project's name in dist.
-      project.root === '.' ? project.name : project.root
-    ),
-    main: determineMain(tree, options),
-    tsConfig: determineTsConfig(tree, options),
-    rspackConfig: joinPathFragments(project.root, 'rspack.config.js'),
-    assets,
-  };
-
-  updateProjectConfiguration(tree, options.project, {
-    ...project,
-    targets: {
-      ...project.targets,
-      build: {
-        executor: '@nrwl/rspack:rspack',
-        outputs: ['{options.outputPath}'],
-        defaultConfiguration: 'production',
-        options: buildOptions,
-        configurations: {
-          development: {
-            mode: 'development',
-          },
-          production: {
-            mode: 'production',
-            optimization: options.target === 'web' ? true : undefined,
-            sourceMap: false,
-          },
-        },
-      },
-    },
-  });
-}
-
-function addServeTarget(tree: Tree, options: ConfigurationSchema) {
-  const project = readProjectConfiguration(tree, options.project);
-  updateProjectConfiguration(tree, options.project, {
-    ...project,
-    targets: {
-      ...project.targets,
-      serve: {
-        executor: '@nrwl/rspack:dev-server',
-        options: {
-          buildTarget: `${options.project}:build:development`,
-        },
-        configurations: {
-          development: {},
-          production: {
-            buildTarget: `${options.project}:build:production`,
-          },
-        },
-      },
-    },
-  });
-}
-
-function writeRspackConfigFile(
-  tree: Tree,
-  options: ConfigurationSchema,
-  stylePreprocessorOptions?: { includePaths?: string[] }
-) {
-  const project = readProjectConfiguration(tree, options.project);
-
-  tree.write(
-    joinPathFragments(project.root, 'rspack.config.js'),
-    createConfig(options, stylePreprocessorOptions)
-  );
-
-  // Remove previous webpack config if they exist
-  if (tree.exists(joinPathFragments(project.root, 'webpack.config.js')))
-    tree.delete(joinPathFragments(project.root, 'webpack.config.js'));
-  if (tree.exists(joinPathFragments(project.root, 'webpack.config.ts')))
-    tree.delete(joinPathFragments(project.root, 'webpack.config.ts'));
-}
-
-function createConfig(
-  options: ConfigurationSchema,
-  stylePreprocessorOptions?: { includePaths?: string[] }
-) {
-  if (options.uiFramework === 'react') {
-    return `
-      const { composePlugins, withNx, withReact } = require('@nrwl/rspack');
-
-      module.exports = composePlugins(withNx(), withReact(${
-        stylePreprocessorOptions
-          ? `
-        {
-          stylePreprocessorOptions: ${JSON.stringify(stylePreprocessorOptions)},
-        }
-        `
-          : ''
-      }), (config) => {
-        return config;
-      });
-    `;
-  } else if (options.uiFramework === 'web' || options.target === 'web') {
-    return `
-      const { composePlugins, withNx, withWeb } = require('@nrwl/rspack');
-
-      module.exports = composePlugins(withNx(), withWeb(${
-        stylePreprocessorOptions
-          ? `
-        {
-          stylePreprocessorOptions: ${JSON.stringify(stylePreprocessorOptions)},
-        }
-        `
-          : ''
-      }), (config) => {
-        return config;
-      });
-    `;
-  } else {
-    return `
-      const { composePlugins, withNx${
-        stylePreprocessorOptions ? ', withWeb' : ''
-      } } = require('@nrwl/rspack');
-
-      module.exports = composePlugins(withNx()${
-        stylePreprocessorOptions
-          ? `,
-        withWeb({
-          stylePreprocessorOptions: ${JSON.stringify(stylePreprocessorOptions)},
-        })`
-          : ''
-      }, (config) => {
-        return config;
-      });
-    `;
-  }
 }
 
 export default configurationGenerator;

--- a/packages/rspack/src/generators/configuration/schema.d.ts
+++ b/packages/rspack/src/generators/configuration/schema.d.ts
@@ -1,4 +1,4 @@
-import { InitGeneratorSchema } from '../init/schema';
+import { Framework, InitGeneratorSchema } from '../init/schema';
 
 export interface ConfigurationSchema extends InitGeneratorSchema {
   project: string;
@@ -6,4 +6,8 @@ export interface ConfigurationSchema extends InitGeneratorSchema {
   tsConfig?: string;
   target?: 'node' | 'web';
   skipValidation?: boolean;
+  newProject?: boolean;
+  buildTarget?: string;
+  serveTarget?: string;
+  framework?: Framework;
 }

--- a/packages/rspack/src/generators/configuration/schema.json
+++ b/packages/rspack/src/generators/configuration/schema.json
@@ -16,6 +16,14 @@
       "x-prompt": "What is the name of the project to set up a rspack for?",
       "x-priority": "important"
     },
+    "framework": {
+      "type": "string",
+      "description": "The framework used by the project.",
+      "x-prompt": "What framework is the project you want to convert using?",
+      "enum": ["none", "react", "web", "nest"],
+      "alias": ["uiFramework"],
+      "x-priority": "important"
+    },
     "main": {
       "type": "string",
       "description": "Path relative to the workspace root for the main entry file. Defaults to '<projectRoot>/src/main.ts'.",
@@ -37,15 +45,24 @@
       "description": "Add a serve target to run a local rspack dev-server",
       "default": false
     },
-    "uiFramework": {
-      "type": "string",
-      "description": "The UI framework used by the project.",
-      "enum": ["none", "react"]
-    },
     "style": {
       "type": "string",
       "description": "The style solution to use.",
       "enum": ["none", "css", "scss", "less"]
+    },
+    "newProject": {
+      "type": "boolean",
+      "description": "Is this a new project?",
+      "default": false,
+      "hidden": true
+    },
+    "buildTarget": {
+      "type": "string",
+      "description": "The build target of the project to be transformed to use the @nrwl/vite:build executor."
+    },
+    "serveTarget": {
+      "type": "string",
+      "description": "The serve target of the project to be transformed to use the @nrwl/vite:dev-server and @nrwl/vite:preview-server executors."
     }
   },
   "required": ["project"]

--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -31,7 +31,7 @@ export async function rspackInitGenerator(
     devDependencies['@rspack/less-loader'] = rspackLessLoaderVersion;
   }
 
-  if (schema.uiFramework !== 'none' || schema.devServer) {
+  if (schema.framework !== 'none' || schema.devServer) {
     devDependencies['@rspack/dev-server'] = rspackDevServerVersion;
   }
 

--- a/packages/rspack/src/generators/init/schema.d.ts
+++ b/packages/rspack/src/generators/init/schema.d.ts
@@ -1,5 +1,7 @@
+export type Framework = 'none' | 'react' | 'web' | 'nest';
+
 export interface InitGeneratorSchema {
-  uiFramework?: 'none' | 'react' | 'web';
+  framework?: Framework;
   style?: 'none' | 'css' | 'scss' | 'less';
   devServer?: boolean;
 }

--- a/packages/rspack/src/generators/init/schema.json
+++ b/packages/rspack/src/generators/init/schema.json
@@ -5,10 +5,11 @@
   "title": "",
   "type": "object",
   "properties": {
-    "uiFramework": {
+    "framework": {
       "type": "string",
       "description": "The UI framework used by the project.",
-      "enum": ["none", "react", "web"]
+      "enum": ["none", "react", "web", "nest"],
+      "alias": ["uiFramework"]
     },
     "style": {
       "type": "string",

--- a/packages/rspack/src/utils/generator-utils.ts
+++ b/packages/rspack/src/utils/generator-utils.ts
@@ -1,0 +1,600 @@
+import {
+  joinPathFragments,
+  logger,
+  readProjectConfiguration,
+  TargetConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nrwl/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { RspackExecutorSchema } from '../executors/rspack/schema';
+import { ConfigurationSchema } from '../generators/configuration/schema';
+import { Framework } from '../generators/init/schema';
+
+export type Target = 'build' | 'serve';
+export type TargetFlags = Partial<Record<Target, boolean>>;
+export type UserProvidedTargetName = Partial<Record<Target, string>>;
+export type ValidFoundTargetName = Partial<Record<Target, string>>;
+
+export function findExistingTargetsInProject(
+  targets: {
+    [targetName: string]: TargetConfiguration;
+  },
+  userProvidedTargets?: UserProvidedTargetName
+): {
+  validFoundTargetName: ValidFoundTargetName;
+  projectContainsUnsupportedExecutor: boolean;
+  userProvidedTargetIsUnsupported: TargetFlags;
+  alreadyHasNxRspackTargets: TargetFlags;
+} {
+  const output: ReturnType<typeof findExistingTargetsInProject> = {
+    validFoundTargetName: {},
+    projectContainsUnsupportedExecutor: false,
+    userProvidedTargetIsUnsupported: {},
+    alreadyHasNxRspackTargets: {},
+  };
+
+  const supportedExecutors = {
+    build: [
+      '@nxext/vite:build',
+      '@nrwl/webpack:webpack',
+      '@nrwl/rollup:rollup',
+      '@nrwl/web:rollup',
+      '@nrwl/vite:build',
+    ],
+    serve: [
+      '@nxext/vite:dev',
+      '@nrwl/webpack:dev-server',
+      '@nrwl/vite:dev-server',
+    ],
+  };
+
+  const unsupportedExecutors = [
+    '@nrwl/js:babel',
+    '@nrwl/js:node',
+    '@nrwl/js:swc',
+    '@nrwl/js:tsc',
+    '@nrwl/angular:ng-packagr-lite',
+    '@nrwl/angular:package',
+    '@nrwl/angular:webpack-browser',
+    '@angular-devkit/build-angular:browser',
+    '@angular-devkit/build-angular:dev-server',
+    '@nrwl/react-native:run-ios',
+    '@nrwl/react-native:start',
+    '@nrwl/react-native:run-android',
+    '@nrwl/react-native:bundle',
+    '@nrwl/react-native:build-android',
+    '@nrwl/react-native:bundle',
+    '@nrwl/next:build',
+    '@nrwl/next:server',
+    '@nrwl/esbuild:esbuild',
+  ];
+
+  // First, we check if the user has provided a target
+  // If they have, we check if the executor the target is using is supported
+  // If it's not supported, then we set the unsupported flag to true for that target
+
+  function checkUserProvidedTarget(target: Target) {
+    if (userProvidedTargets?.[target]) {
+      if (
+        supportedExecutors[target].includes(
+          targets[userProvidedTargets[target]]?.executor
+        )
+      ) {
+        output.validFoundTargetName[target] = userProvidedTargets[target];
+      } else {
+        output.userProvidedTargetIsUnsupported[target] = true;
+      }
+    }
+  }
+
+  checkUserProvidedTarget('build');
+  checkUserProvidedTarget('serve');
+
+  // Returns early when we have a build, serve, and test targets.
+  if (output.validFoundTargetName.build && output.validFoundTargetName.serve) {
+    return output;
+  }
+
+  // We try to find the targets that are using the supported executors
+  // for build, serve and test, since these are the ones we will be converting
+  for (const target in targets) {
+    const executorName = targets[target].executor;
+
+    const hasRspackTargets = output.alreadyHasNxRspackTargets;
+    hasRspackTargets.build ||= executorName === '@nrwl/rspack:rspack';
+    hasRspackTargets.serve ||= executorName === '@nrwl/rspack:dev-server';
+
+    const foundTargets = output.validFoundTargetName;
+    if (
+      !foundTargets.build &&
+      supportedExecutors.build.includes(executorName)
+    ) {
+      foundTargets.build = target;
+    }
+    if (
+      !foundTargets.serve &&
+      supportedExecutors.serve.includes(executorName)
+    ) {
+      foundTargets.serve = target;
+    }
+
+    output.projectContainsUnsupportedExecutor ||=
+      unsupportedExecutors.includes(executorName);
+  }
+
+  return output;
+}
+
+export function addOrChangeBuildTarget(
+  tree: Tree,
+  options: ConfigurationSchema,
+  target: string
+) {
+  const project = readProjectConfiguration(tree, options.project);
+  const assets = [];
+  if (
+    options.target === 'web' &&
+    tree.exists(joinPathFragments(project.root, 'src/favicon.ico'))
+  ) {
+    assets.push(joinPathFragments(project.root, 'src/favicon.ico'));
+  }
+  if (tree.exists(joinPathFragments(project.root, 'src/assets'))) {
+    assets.push(joinPathFragments(project.root, 'src/assets'));
+  }
+
+  const buildOptions: RspackExecutorSchema = {
+    target: options.target ?? 'web',
+    outputPath: joinPathFragments(
+      'dist',
+      // If standalone project then use the project's name in dist.
+      project.root === '.' ? project.name : project.root
+    ),
+    main: determineMain(tree, options),
+    tsConfig: determineTsConfig(tree, options),
+    rspackConfig: joinPathFragments(project.root, 'rspack.config.js'),
+    assets,
+  };
+
+  project.targets ??= {};
+
+  project.targets[target] = {
+    executor: '@nrwl/rspack:rspack',
+    outputs: ['{options.outputPath}'],
+    defaultConfiguration: 'production',
+    options: buildOptions,
+    configurations: {
+      development: {
+        mode: 'development',
+      },
+      production: {
+        mode: 'production',
+        optimization: options.target === 'web' ? true : undefined,
+        sourceMap: false,
+      },
+    },
+  };
+
+  updateProjectConfiguration(tree, options.project, project);
+}
+
+export function addOrChangeServeTarget(
+  tree: Tree,
+  options: ConfigurationSchema,
+  target: string
+) {
+  const project = readProjectConfiguration(tree, options.project);
+
+  project.targets ??= {};
+
+  project.targets[target] = {
+    executor: '@nrwl/rspack:dev-server',
+    options: {
+      buildTarget: `${options.project}:build:development`,
+    },
+    configurations: {
+      development: {},
+      production: {
+        buildTarget: `${options.project}:build:production`,
+      },
+    },
+  };
+
+  updateProjectConfiguration(tree, options.project, project);
+}
+
+export function writeRspackConfigFile(
+  tree: Tree,
+  options: ConfigurationSchema,
+  stylePreprocessorOptions?: { includePaths?: string[] }
+) {
+  const project = readProjectConfiguration(tree, options.project);
+
+  tree.write(
+    joinPathFragments(project.root, 'rspack.config.js'),
+    createConfig(options, stylePreprocessorOptions)
+  );
+}
+
+function createConfig(
+  options: ConfigurationSchema,
+  stylePreprocessorOptions?: { includePaths?: string[] }
+) {
+  if (options.framework === 'react') {
+    return `
+      const { composePlugins, withNx, withReact } = require('@nrwl/rspack');
+
+      module.exports = composePlugins(withNx(), withReact(${
+        stylePreprocessorOptions
+          ? `
+        {
+          stylePreprocessorOptions: ${JSON.stringify(stylePreprocessorOptions)},
+        }
+        `
+          : ''
+      }), (config) => {
+        return config;
+      });
+    `;
+  } else if (options.framework === 'web' || options.target === 'web') {
+    return `
+      const { composePlugins, withNx, withWeb } = require('@nrwl/rspack');
+
+      module.exports = composePlugins(withNx(), withWeb(${
+        stylePreprocessorOptions
+          ? `
+        {
+          stylePreprocessorOptions: ${JSON.stringify(stylePreprocessorOptions)},
+        }
+        `
+          : ''
+      }), (config) => {
+        return config;
+      });
+    `;
+  } else if (options.framework === 'nest') {
+    return `
+    const { composePlugins, withNx } = require('@nrwl/rspack');
+
+    module.exports = composePlugins(withNx(), (config) => {
+      ${
+        options.main
+          ? `config.entry = {
+          main: './${options.main}',
+          };`
+          : ``
+      }
+      return config;
+    });
+    `;
+  } else {
+    return `
+      const { composePlugins, withNx${
+        stylePreprocessorOptions ? ', withWeb' : ''
+      } } = require('@nrwl/rspack');
+
+      module.exports = composePlugins(withNx()${
+        stylePreprocessorOptions
+          ? `,
+        withWeb({
+          stylePreprocessorOptions: ${JSON.stringify(stylePreprocessorOptions)},
+        })`
+          : ''
+      }, (config) => {
+        return config;
+      });
+    `;
+  }
+}
+
+export function deleteWebpackConfig(
+  tree: Tree,
+  projectRoot: string,
+  webpackConfigFilePath?: string
+) {
+  const webpackConfigPath =
+    webpackConfigFilePath && tree.exists(webpackConfigFilePath)
+      ? webpackConfigFilePath
+      : tree.exists(`${projectRoot}/webpack.config.js`)
+      ? `${projectRoot}/webpack.config.js`
+      : tree.exists(`${projectRoot}/webpack.config.ts`)
+      ? `${projectRoot}/webpack.config.ts`
+      : null;
+  if (webpackConfigPath) {
+    tree.delete(webpackConfigPath);
+  }
+}
+
+// Maybe add delete vite config?
+
+export function moveAndEditIndexHtml(
+  tree: Tree,
+  options: ConfigurationSchema,
+  buildTarget: string
+) {
+  const projectConfig = readProjectConfiguration(tree, options.project);
+
+  let indexHtmlPath =
+    projectConfig.targets?.[buildTarget]?.options?.index ??
+    `${projectConfig.root}/src/index.html`;
+  let mainPath =
+    projectConfig.targets?.[buildTarget]?.options?.main ??
+    `${projectConfig.root}/src/main.ts${
+      options.framework === 'react' ? 'x' : ''
+    }`;
+
+  if (projectConfig.root !== '.') {
+    mainPath = mainPath.replace(projectConfig.root, '');
+  }
+
+  if (
+    !tree.exists(indexHtmlPath) &&
+    tree.exists(`${projectConfig.root}/index.html`)
+  ) {
+    indexHtmlPath = `${projectConfig.root}/index.html`;
+  }
+
+  if (tree.exists(indexHtmlPath)) {
+    const indexHtmlContent = tree.read(indexHtmlPath, 'utf8');
+    if (
+      !indexHtmlContent.includes(
+        `<script type="module" src="${mainPath}"></script>`
+      )
+    ) {
+      tree.write(
+        `${projectConfig.root}/index.html`,
+        indexHtmlContent.replace(
+          '</body>',
+          `<script type="module" src="${mainPath}"></script>
+          </body>`
+        )
+      );
+
+      if (tree.exists(`${projectConfig.root}/src/index.html`)) {
+        tree.delete(`${projectConfig.root}/src/index.html`);
+      }
+    }
+  } else {
+    tree.write(
+      `${projectConfig.root}/index.html`,
+      `<!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="UTF-8" />
+          <link rel="icon" href="/favicon.ico" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <title>Vite</title>
+        </head>
+        <body>
+          <div id="root"></div>
+          <script type="module" src="${mainPath}"></script>
+        </body>
+      </html>`
+    );
+  }
+}
+
+export function normalizeViteConfigFilePathWithTree(
+  tree: Tree,
+  projectRoot: string,
+  configFile?: string
+): string {
+  return configFile && tree.exists(configFile)
+    ? configFile
+    : tree.exists(joinPathFragments(`${projectRoot}/rspack.config.ts`))
+    ? joinPathFragments(`${projectRoot}/rspack.config.ts`)
+    : tree.exists(joinPathFragments(`${projectRoot}/rspack.config.js`))
+    ? joinPathFragments(`${projectRoot}/rspack.config.js`)
+    : undefined;
+}
+
+export function getViteConfigPathForProject(
+  tree: Tree,
+  projectName: string,
+  target?: string
+) {
+  let viteConfigPath: string | undefined;
+  const { targets, root } = readProjectConfiguration(tree, projectName);
+  if (target) {
+    viteConfigPath = targets?.[target]?.options?.configFile;
+  } else {
+    const config = Object.values(targets).find(
+      (config) => config.executor === '@nrwl/rspack:build'
+    );
+    viteConfigPath = config?.options?.configFile;
+  }
+
+  return normalizeViteConfigFilePathWithTree(tree, root, viteConfigPath);
+}
+
+export async function handleUnsupportedUserProvidedTargets(
+  userProvidedTargetIsUnsupported: TargetFlags,
+  userProvidedTargetName: UserProvidedTargetName,
+  validFoundTargetName: ValidFoundTargetName,
+  framework: Framework
+) {
+  if (userProvidedTargetIsUnsupported.build && validFoundTargetName.build) {
+    await handleUnsupportedUserProvidedTargetsErrors(
+      userProvidedTargetName.build,
+      validFoundTargetName.build,
+      'build',
+      'rspack'
+    );
+  }
+
+  if (
+    framework !== 'nest' &&
+    userProvidedTargetIsUnsupported.serve &&
+    validFoundTargetName.serve
+  ) {
+    await handleUnsupportedUserProvidedTargetsErrors(
+      userProvidedTargetName.serve,
+      validFoundTargetName.serve,
+      'serve',
+      'dev-server'
+    );
+  }
+}
+
+async function handleUnsupportedUserProvidedTargetsErrors(
+  userProvidedTargetName: string,
+  validFoundTargetName: string,
+  target: Target,
+  executor: 'rspack' | 'dev-server'
+) {
+  logger.warn(
+    `The custom ${target} target you provided (${userProvidedTargetName}) cannot be converted to use the @nrwl/rspack:${executor} executor.
+     However, we found the following ${target} target in your project that can be converted: ${validFoundTargetName}
+
+     Please note that converting a potentially non-compatible project to use Vite.js may result in unexpected behavior. Always commit
+     your changes before converting a project to use Vite.js, and test the converted project thoroughly before deploying it.
+    `
+  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Confirm } = require('enquirer');
+  const prompt = new Confirm({
+    name: 'question',
+    message: `Should we convert the ${validFoundTargetName} target to use the @nrwl/rspack:${executor} executor?`,
+    initial: true,
+  });
+  const shouldConvert = await prompt.run();
+  if (!shouldConvert) {
+    throw new Error(
+      `The ${target} target ${userProvidedTargetName} cannot be converted to use the @nrwl/rspack:${executor} executor.
+      Please try again, either by providing a different ${target} target or by not providing a target at all (Nx will
+        convert the first one it finds, most probably this one: ${validFoundTargetName})
+
+      Please note that converting a potentially non-compatible project to use Vite.js may result in unexpected behavior. Always commit
+      your changes before converting a project to use Vite.js, and test the converted project thoroughly before deploying it.
+      `
+    );
+  }
+}
+
+export async function handleUnknownExecutors(projectName: string) {
+  logger.warn(
+    `
+      We could not find any targets in project ${projectName} that use executors which 
+      can be converted to the @nrwl/rspack executors.
+
+      This either means that your project may not have a target 
+      for building, serving, or testing at all, or that your targets are 
+      using executors that are not known to Nx.
+      
+      If you still want to convert your project to use the @nrwl/rspack executors,
+      please make sure to commit your changes before running this generator.
+      `
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Confirm } = require('enquirer');
+  const prompt = new Confirm({
+    name: 'question',
+    message: `Should Nx convert your project to use the @nrwl/rspack executors?`,
+    initial: true,
+  });
+  const shouldConvert = await prompt.run();
+  if (!shouldConvert) {
+    throw new Error(`
+      Nx could not verify that the executors you are using can be converted to the @nrwl/rspack executors.
+      Please try again with a different project.
+    `);
+  }
+}
+
+export function determineFrameworkAndTarget(
+  tree: Tree,
+  options: ConfigurationSchema,
+  projectRoot: string,
+  targets: {
+    [targetName: string]: TargetConfiguration<any>;
+  }
+): { target: 'node' | 'web'; framework?: Framework } {
+  // First try to infer if the target is node
+  if (options.target !== 'node') {
+    // Try to infer from jest config if the env is node
+    let jestConfigPath: string;
+    if (
+      targets?.test?.executor !== '@nrwl/jest:jest' &&
+      targets?.test?.options?.jestConfig
+    ) {
+      jestConfigPath = targets?.test?.options?.jestConfig;
+    } else {
+      jestConfigPath = joinPathFragments(projectRoot, 'jest.config.ts');
+    }
+
+    if (!tree.exists(jestConfigPath)) {
+      return { target: options.target, framework: options.framework };
+    }
+    const appFileContent = tree.read(jestConfigPath, 'utf-8');
+    const file = tsquery.ast(appFileContent);
+    // find testEnvironment: 'node' in jest config
+    const testEnvironment = tsquery(
+      file,
+      `PropertyAssignment:has(Identifier[name="testEnvironment"]) > StringLiteral[value="node"]`
+    );
+    if (testEnvironment.length > 0) {
+      return { target: 'node', framework: options.framework };
+    }
+
+    if (tree.exists(joinPathFragments(projectRoot, 'src/main.ts'))) {
+      const appFileContent = tree.read(
+        joinPathFragments(projectRoot, 'src/main.ts'),
+        'utf-8'
+      );
+      const file = tsquery.ast(appFileContent);
+      const hasNestJsDependency = tsquery(
+        file,
+        `ImportDeclaration:has(StringLiteral[value="@nestjs/common"])`
+      );
+      if (hasNestJsDependency?.length > 0) {
+        return { target: 'node', framework: 'nest' };
+      }
+    }
+  }
+
+  if (options.framework === 'nest') {
+    return { target: 'node', framework: 'nest' };
+  }
+
+  if (options.framework !== 'react' && options.target === 'web') {
+    // Look if React is used in the project
+    let tsConfigPath = joinPathFragments(projectRoot, 'tsconfig.json');
+    if (!tree.exists(tsConfigPath)) {
+      tsConfigPath = determineTsConfig(tree, options);
+    }
+    const tsConfig = JSON.parse(tree.read(tsConfigPath).toString());
+    if (tsConfig?.compilerOptions?.jsx?.includes('react')) {
+      return { target: 'web', framework: 'react' };
+    } else {
+      return { target: options.target, framework: options.framework };
+    }
+  }
+
+  return { target: options.target, framework: options.framework };
+}
+
+export function determineMain(tree: Tree, options: ConfigurationSchema) {
+  if (options.main) return options.main;
+
+  const project = readProjectConfiguration(tree, options.project);
+
+  const mainTsx = joinPathFragments(project.root, 'src/main.tsx');
+  if (tree.exists(mainTsx)) return mainTsx;
+
+  return joinPathFragments(project.root, 'src/main.ts');
+}
+
+export function determineTsConfig(tree: Tree, options: ConfigurationSchema) {
+  if (options.tsConfig) return options.tsConfig;
+
+  const project = readProjectConfiguration(tree, options.project);
+
+  const appJson = joinPathFragments(project.root, 'tsconfig.app.json');
+  if (tree.exists(appJson)) return appJson;
+
+  const libJson = joinPathFragments(project.root, 'tsconfig.lib.json');
+  if (tree.exists(libJson)) return libJson;
+
+  return joinPathFragments(project.root, 'tsconfig.json');
+}


### PR DESCRIPTION
Make the `rspack:configuration` generator work like the `vite:configuration` generator. It only accepts a specific type of executors that can be converted. It tries to infer what type of project the user is trying to convert. It allows user to specify framework to be used when converting (`react`, `web`, `nest`).