### PR TITLE
feat(rspack): accept and return outputFileName

### DIFF
--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -22,7 +22,7 @@ export default async function runExecutor(
 
   const compiler = await createCompiler(options, context);
 
-  return new Promise<{ success: boolean }>((res) => {
+  return new Promise<{ success: boolean; outfile?: string }>((res) => {
     compiler.run((error, stats) => {
       compiler.close(() => {
         if (error) {
@@ -44,7 +44,10 @@ export default async function runExecutor(
         if (printedStats) {
           console.error(printedStats);
         }
-        res({ success: !stats.hasErrors() });
+        res({
+          success: !stats.hasErrors(),
+          outfile: path.resolve(context.root, options.outputPath, 'main.js'),
+        });
       });
     });
   });


### PR DESCRIPTION
Rspack now returns the outfile name, and also accepts an output file name as input. This should solve issues with serving Nest apps, and also enhances the functionality, makes it more consistent with other builders.