### PR TITLE
feat(remix): quality of life improvements for Remix generators

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -95,7 +95,7 @@ describe('remix e2e', () => {
       );
 
       expect(result.stdout).toContain(
-        `CREATE apps/${plugin}/app/routes/my.route.$withParams.tsx`
+        `CREATE ${plugin}/app/routes/my.route.$withParams.tsx`
       );
     }, 120000);
 
@@ -103,7 +103,7 @@ describe('remix e2e', () => {
       const result =  await runCommandAsync(`someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`);
 
       expect(result.stdout).toContain(
-        `CREATE apps/${plugin}/app/routes/my.route.route-segment.tsx`
+        `CREATE ${plugin}/app/routes/my.route.route-segment.tsx`
       );
     }, 120000);
 
@@ -122,7 +122,7 @@ describe('remix e2e', () => {
       );
 
       expect(result.stdout).toContain(
-        `CREATE apps/${plugin}/app/routes/my.route.$withParams.ts`
+        `CREATE ${plugin}/app/routes/my.route.$withParams.ts`
       );
     }, 120000);
 
@@ -130,7 +130,7 @@ describe('remix e2e', () => {
       const result =  await runCommandAsync(`someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`);
 
       expect(result.stdout).toContain(
-        `CREATE apps/${plugin}/app/routes/my.route.route-segment.ts`
+        `CREATE ${plugin}/app/routes/my.route.route-segment.ts`
       );
     }, 120000);
   });

--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -1,6 +1,6 @@
 import {
   ensureNxProject,
-  readJson,
+  readJson, runCommandAsync,
   runNxCommandAsync,
   uniq,
   updateFile,
@@ -68,6 +68,70 @@ describe('remix e2e', () => {
       );
       const project = readJson(`${plugin}/project.json`);
       expect(project.tags).toEqual(['e2etag', 'e2ePackage']);
+    }, 120000);
+  });
+
+  describe('error checking', () => {
+    const plugin = uniq('remix');
+
+    beforeAll(async () => {
+      await runNxCommandAsync(
+        `generate @nrwl/remix:app ${plugin} --tags e2etag,e2ePackage`
+      );
+    }, 120000);
+
+    it('should check for un-escaped dollar signs in routes', async () => {
+      expect.assertions(2);
+      try {
+        await runNxCommandAsync(
+          `generate @nrwl/remix:route --project ${plugin} --path my.route.$withParams.tsx`
+        );
+      } catch (e) {
+        expect(e.toString()).toContain('Error: Command failed:');
+      }
+
+      const result = await runNxCommandAsync(
+        `generate @nrwl/remix:route --project ${plugin} --path my.route.\\$withParams.tsx`
+      );
+
+      expect(result.stdout).toContain(
+        `CREATE apps/${plugin}/app/routes/my.route.$withParams.tsx`
+      );
+    }, 120000);
+
+    it('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
+      const result =  await runCommandAsync(`someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`);
+
+      expect(result.stdout).toContain(
+        `CREATE apps/${plugin}/app/routes/my.route.route-segment.tsx`
+      );
+    }, 120000);
+
+    it('should check for un-escaped dollar signs in resource routes', async () => {
+      expect.assertions(2);
+      try {
+        await runNxCommandAsync(
+          `generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$withParams.ts`
+        );
+      } catch (e) {
+        expect(e.toString()).toContain('Error: Command failed:');
+      }
+
+      const result = await runNxCommandAsync(
+        `generate @nrwl/remix:resource-route --project ${plugin} --path my.route.\\$withParams.ts`
+      );
+
+      expect(result.stdout).toContain(
+        `CREATE apps/${plugin}/app/routes/my.route.$withParams.ts`
+      );
+    }, 120000);
+
+    it('should pass un-escaped dollar signs in resource routes with skipChecks flag', async () => {
+      const result =  await runCommandAsync(`someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`);
+
+      expect(result.stdout).toContain(
+        `CREATE apps/${plugin}/app/routes/my.route.route-segment.ts`
+      );
     }, 120000);
   });
 });

--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -1,4 +1,5 @@
 import {
+  checkFilesExist,
   ensureNxProject,
   readJson,
   runCommandAsync,
@@ -82,61 +83,57 @@ describe('remix e2e', () => {
     }, 120000);
 
     it('should check for un-escaped dollar signs in routes', async () => {
-      expect.assertions(2);
-      try {
-        await runNxCommandAsync(
-          `generate @nrwl/remix:route --project ${plugin} --path my.route.$withParams.tsx`
-        );
-      } catch (e) {
-        expect(e.toString()).toContain('Error: Command failed:');
-      }
+      await expect(
+        async () =>
+          await runNxCommandAsync(
+            `generate @nrwl/remix:route --project ${plugin} --path my.route.$withParams.tsx`
+          )
+      ).rejects.toThrow();
 
-      const result = await runNxCommandAsync(
+      await runNxCommandAsync(
         `generate @nrwl/remix:route --project ${plugin} --path my.route.\\$withParams.tsx`
       );
 
-      expect(result.stdout).toContain(
-        `CREATE ${plugin}/app/routes/my.route.$withParams.tsx`
-      );
+      expect(() =>
+        checkFilesExist(`${plugin}/app/routes/my.route.$withParams.tsx`)
+      ).not.toThrow();
     }, 120000);
 
     it('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
-      const result = await runCommandAsync(
+      await runCommandAsync(
         `someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`
       );
 
-      expect(result.stdout).toContain(
-        `CREATE ${plugin}/app/routes/my.route.route-segment.tsx`
-      );
+      expect(() =>
+        checkFilesExist(`${plugin}/app/routes/my.route.route-segment.tsx`)
+      ).not.toThrow();
     }, 120000);
 
     it('should check for un-escaped dollar signs in resource routes', async () => {
-      expect.assertions(2);
-      try {
-        await runNxCommandAsync(
-          `generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$withParams.ts`
-        );
-      } catch (e) {
-        expect(e.toString()).toContain('Error: Command failed:');
-      }
+      await expect(
+        async () =>
+          await runNxCommandAsync(
+            `generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$withParams.ts`
+          )
+      ).rejects.toThrow();
 
-      const result = await runNxCommandAsync(
+      await runNxCommandAsync(
         `generate @nrwl/remix:resource-route --project ${plugin} --path my.route.\\$withParams.ts`
       );
 
-      expect(result.stdout).toContain(
-        `CREATE ${plugin}/app/routes/my.route.$withParams.ts`
-      );
+      expect(() =>
+        checkFilesExist(`${plugin}/app/routes/my.route.$withParams.ts`)
+      ).not.toThrow();
     }, 120000);
 
     it('should pass un-escaped dollar signs in resource routes with skipChecks flag', async () => {
-      const result = await runCommandAsync(
-        `someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`
+      await runCommandAsync(
+        `someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.ts --force`
       );
 
-      expect(result.stdout).toContain(
-        `CREATE ${plugin}/app/routes/my.route.route-segment.ts`
-      );
+      expect(() =>
+        checkFilesExist(`${plugin}/app/routes/my.route.route-segment.ts`)
+      ).not.toThrow();
     }, 120000);
   });
 });

--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -1,6 +1,7 @@
 import {
   ensureNxProject,
-  readJson, runCommandAsync,
+  readJson,
+  runCommandAsync,
   runNxCommandAsync,
   uniq,
   updateFile,
@@ -100,7 +101,9 @@ describe('remix e2e', () => {
     }, 120000);
 
     it('should pass un-escaped dollar signs in routes with skipChecks flag', async () => {
-      const result =  await runCommandAsync(`someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`);
+      const result = await runCommandAsync(
+        `someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`
+      );
 
       expect(result.stdout).toContain(
         `CREATE ${plugin}/app/routes/my.route.route-segment.tsx`
@@ -127,7 +130,9 @@ describe('remix e2e', () => {
     }, 120000);
 
     it('should pass un-escaped dollar signs in resource routes with skipChecks flag', async () => {
-      const result =  await runCommandAsync(`someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`);
+      const result = await runCommandAsync(
+        `someWeirdUseCase=route-segment && yarn nx generate @nrwl/remix:resource-route --project ${plugin} --path my.route.$someWeirdUseCase.tsx --force`
+      );
 
       expect(result.stdout).toContain(
         `CREATE ${plugin}/app/routes/my.route.route-segment.ts`

--- a/packages/remix/src/generators/action/action.impl.spec.ts
+++ b/packages/remix/src/generators/action/action.impl.spec.ts
@@ -19,6 +19,7 @@ describe('action', () => {
       loader: false,
       action: false,
       meta: false,
+      skipChecks: false
     });
   });
 

--- a/packages/remix/src/generators/action/action.impl.spec.ts
+++ b/packages/remix/src/generators/action/action.impl.spec.ts
@@ -19,7 +19,7 @@ describe('action', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
   });
 
@@ -44,9 +44,7 @@ describe('action', () => {
       });
       it('should add imports', async () => {
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
-        expect(content).toMatch(
-          `import { json } from '@remix-run/node';`
-        );
+        expect(content).toMatch(`import { json } from '@remix-run/node';`);
         expect(content).toMatch(
           `import type { ActionArgs } from '@remix-run/node';`
         );

--- a/packages/remix/src/generators/action/action.impl.spec.ts
+++ b/packages/remix/src/generators/action/action.impl.spec.ts
@@ -44,18 +44,24 @@ describe('action', () => {
       it('should add imports', async () => {
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
         expect(content).toMatch(
-          `import type { ActionFunction } from '@remix-run/node';`
+          `import { json } from '@remix-run/node';`
+        );
+        expect(content).toMatch(
+          `import type { ActionArgs } from '@remix-run/node';`
+        );
+        expect(content).toMatch(
+          `import { useActionData } from '@remix-run/react';`
         );
       });
 
       it('should add action function', () => {
-        const actionFunction = `type ExampleActionData = {`;
+        const actionFunction = `export const action = async ({ request }: ActionArgs)`;
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
         expect(content).toMatch(actionFunction);
       });
 
       it('should add useActionData to component', () => {
-        const useActionData = `export default function Example() {`;
+        const useActionData = `const actionMessage = useActionData<typeof action>();`;
 
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
         expect(content).toMatch(useActionData);

--- a/packages/remix/src/generators/action/action.impl.ts
+++ b/packages/remix/src/generators/action/action.impl.ts
@@ -1,10 +1,9 @@
 import { formatFiles, Tree } from '@nrwl/devkit';
-import { LoaderSchema } from './schema';
 import { insertImport } from '../../utils/insert-import';
 import { insertStatementAfterImports } from '../../utils/insert-statement-after-imports';
-import { getDefaultExportName } from '../../utils/get-default-export-name';
 import { insertStatementInDefaultFunction } from '../../utils/insert-statement-in-default-function';
 import { resolveRemixRouteFile } from '../../utils/remix-route-utils';
+import { LoaderSchema } from './schema';
 
 export default async function (tree: Tree, schema: LoaderSchema) {
   const routeFilePath = resolveRemixRouteFile(
@@ -24,7 +23,6 @@ export default async function (tree: Tree, schema: LoaderSchema) {
   });
   insertImport(tree, routeFilePath, 'json', '@remix-run/node');
   insertImport(tree, routeFilePath, 'useActionData', '@remix-run/react');
-
 
   insertStatementAfterImports(
     tree,

--- a/packages/remix/src/generators/action/action.impl.ts
+++ b/packages/remix/src/generators/action/action.impl.ts
@@ -19,33 +19,27 @@ export default async function (tree: Tree, schema: LoaderSchema) {
     );
   }
 
-  insertImport(tree, routeFilePath, 'ActionFunction', '@remix-run/node', {
+  insertImport(tree, routeFilePath, 'ActionArgs', '@remix-run/node', {
     typeOnly: true,
   });
   insertImport(tree, routeFilePath, 'json', '@remix-run/node');
   insertImport(tree, routeFilePath, 'useActionData', '@remix-run/react');
 
-  const defaultExportName = getDefaultExportName(tree, routeFilePath);
-  const actionTypeName = `${defaultExportName}ActionData`;
 
   insertStatementAfterImports(
     tree,
     routeFilePath,
     `
-    type ${actionTypeName} = {
-        message: string;
-    };
-    
-    export let action: ActionFunction = async ({ request }) => {
+    export const action = async ({ request }: ActionArgs) => {
       let formData = await request.formData();
-  
+
       return json({message: formData.toString()}, { status: 200 });
     };
-    
+
     `
   );
 
-  const statement = `\nconst actionMessage = useActionData<${actionTypeName}>();`;
+  const statement = `\nconst actionMessage = useActionData<typeof action>();`;
 
   try {
     insertStatementInDefaultFunction(tree, routeFilePath, statement);

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -12,7 +12,7 @@ import {
 
 } from '@nrwl/devkit';
 import { extractTsConfigBase } from '@nrwl/js/src/utils/typescript/create-ts-config';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { runTasksInSerial } from '@nrwl/devkit';
 import {
   eslintVersion,
   isbotVersion,

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -7,12 +7,11 @@ import {
   joinPathFragments,
   offsetFromRoot,
   readJson,
+  runTasksInSerial,
   Tree,
   updateJson,
-
 } from '@nrwl/devkit';
 import { extractTsConfigBase } from '@nrwl/js/src/utils/typescript/create-ts-config';
-import { runTasksInSerial } from '@nrwl/devkit';
 import {
   eslintVersion,
   isbotVersion,

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -9,6 +9,7 @@ import {
   readJson,
   Tree,
   updateJson,
+
 } from '@nrwl/devkit';
 import { extractTsConfigBase } from '@nrwl/js/src/utils/typescript/create-ts-config';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';

--- a/packages/remix/src/generators/cypress/cypress.impl.ts
+++ b/packages/remix/src/generators/cypress/cypress.impl.ts
@@ -4,7 +4,7 @@ import {
   Tree,
 } from '@nrwl/devkit';
 
-import { cypressProjectGenerator, cypressInitGenerator } from '@nrwl/cypress';
+import { cypressInitGenerator, cypressProjectGenerator } from '@nrwl/cypress';
 
 export default async function (tree: Tree, options: any) {
   const initSideEffects = await cypressInitGenerator(tree, {});

--- a/packages/remix/src/generators/cypress/cypress.impl.ts
+++ b/packages/remix/src/generators/cypress/cypress.impl.ts
@@ -21,10 +21,37 @@ export default async function (tree: Tree, options: any) {
   beforeEach(() => cy.visit('/'));
 
   it('should display welcome message', () => {
-    cy.get('h2').contains('Welcome to Remix!');
+    cy.get('h1').contains('Welcome to Remix');
   });
 });`
   );
+
+  const supportFilePath = joinPathFragments(
+    config.sourceRoot,
+    'support',
+    'e2e.ts'
+  );
+  const supportContent = tree.read(supportFilePath, 'utf-8');
+
+  tree.write(
+    supportFilePath,
+    `${supportContent}
+
+// from https://github.com/remix-run/indie-stack
+Cypress.on("uncaught:exception", (err) => {
+  // Cypress and React Hydrating the document don't get along
+  // for some unknown reason. Hopefully we figure out why eventually
+  // so we can remove this.
+  if (
+    /hydrat/i.test(err.message) ||
+    /Minified React error #418/.test(err.message) ||
+    /Minified React error #423/.test(err.message)
+  ) {
+    return false;
+  }
+});`
+  );
+
   // returning this in case the cypress generator has any side effects
   return async () => {
     await initSideEffects;

--- a/packages/remix/src/generators/cypress/cypress.impl.ts
+++ b/packages/remix/src/generators/cypress/cypress.impl.ts
@@ -7,8 +7,8 @@ import {
 import { cypressProjectGenerator, cypressInitGenerator } from '@nrwl/cypress';
 
 export default async function (tree: Tree, options: any) {
-  const initSideEffects = cypressInitGenerator(tree, {});
-  const projSideEffects = cypressProjectGenerator(tree, {
+  const initSideEffects = await cypressInitGenerator(tree, {});
+  const projSideEffects = await cypressProjectGenerator(tree, {
     ...options,
     standaloneConfig: true,
   });
@@ -16,7 +16,7 @@ export default async function (tree: Tree, options: any) {
   const config = readProjectConfiguration(tree, options.name);
   tree.delete(joinPathFragments(config.sourceRoot, 'support', 'app.po.ts'));
   tree.write(
-    joinPathFragments(config.sourceRoot, 'integration', 'app.spec.ts'),
+    joinPathFragments(config.sourceRoot, 'e2e', 'app.cy.ts'),
     `describe('webapp', () => {
   beforeEach(() => cy.visit('/'));
 

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -13,7 +13,7 @@ import { libraryGenerator } from '@nrwl/react/src/generators/library/library';
 import { NxRemixGeneratorSchema } from './schema';
 import { Linter } from '@nrwl/linter';
 import { execSync } from 'child_process';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { runTasksInSerial } from '@nrwl/devkit';
 
 export default async function (tree: Tree, options: NxRemixGeneratorSchema) {
   const tasks: GeneratorCallback[] = [];
@@ -24,12 +24,7 @@ export default async function (tree: Tree, options: NxRemixGeneratorSchema) {
 
   const libGenTask = await libraryGenerator(tree, {
     name,
-
-    // Remix can only work with buildable libs and yarn/npm workspaces
-    buildable: true,
-    compiler: 'babel',
-
-    style: 'css',
+    style: options.style,
     unitTestRunner: 'jest',
     tags: options.tags,
     importPath: options.importPath,

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -5,15 +5,15 @@ import {
   joinPathFragments,
   names,
   readProjectConfiguration,
+  runTasksInSerial,
   Tree,
   updateJson,
   updateProjectConfiguration,
 } from '@nrwl/devkit';
-import { libraryGenerator } from '@nrwl/react/src/generators/library/library';
-import { NxRemixGeneratorSchema } from './schema';
 import { Linter } from '@nrwl/linter';
+import { libraryGenerator } from '@nrwl/react/src/generators/library/library';
 import { execSync } from 'child_process';
-import { runTasksInSerial } from '@nrwl/devkit';
+import { NxRemixGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, options: NxRemixGeneratorSchema) {
   const tasks: GeneratorCallback[] = [];

--- a/packages/remix/src/generators/library/schema.d.ts
+++ b/packages/remix/src/generators/library/schema.d.ts
@@ -1,4 +1,4 @@
-import {SupportedStyles} from "@nrwl/react";
+import { SupportedStyles } from '@nrwl/react';
 
 export interface NxRemixGeneratorSchema {
   name: string;

--- a/packages/remix/src/generators/library/schema.d.ts
+++ b/packages/remix/src/generators/library/schema.d.ts
@@ -1,6 +1,9 @@
+import {SupportedStyles} from "@nrwl/react";
+
 export interface NxRemixGeneratorSchema {
   name: string;
   tags?: string;
   importPath?: string;
   js?: boolean;
+  style: SupportedStyles;
 }

--- a/packages/remix/src/generators/library/schema.json
+++ b/packages/remix/src/generators/library/schema.json
@@ -25,6 +25,12 @@
       "type": "string",
       "description": "Add tags to the library (used for linting)"
     },
+    "style": {
+      "type": "string",
+      "description": "Generate a stylesheet",
+      "enum": ["none", "css"],
+      "default": "css"
+    },
     "importPath": {
       "type": "string",
       "description": "The library name used to import it, like @myorg/my-awesome-lib"

--- a/packages/remix/src/generators/loader/loader.impl.spec.ts
+++ b/packages/remix/src/generators/loader/loader.impl.spec.ts
@@ -44,20 +44,24 @@ describe('loader', () => {
       it('should add imports', async () => {
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
         expect(content).toMatch(
-          `import type { LoaderFunction } from '@remix-run/node';`
+          `import { json } from '@remix-run/node';`
+        );
+        expect(content).toMatch(
+          `import type { LoaderArgs } from '@remix-run/node';`
+        );
+        expect(content).toMatch(
+          `import { useLoaderData } from '@remix-run/react';`
         );
       });
 
       it('should add loader function', () => {
-        const loaderFunctionType = `type ExampleLoaderData`;
-        const loaderFunction = `export const loader: LoaderFunction = async`;
+        const loaderFunction = `export const loader = async`;
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
-        expect(content).toMatch(loaderFunctionType);
         expect(content).toMatch(loaderFunction);
       });
 
       it('should add useLoaderData to component', () => {
-        const useLoaderData = `const data = useLoaderData<ExampleLoaderData>();`;
+        const useLoaderData = `const data = useLoaderData<typeof loader>();`;
 
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
         expect(content).toMatch(useLoaderData);

--- a/packages/remix/src/generators/loader/loader.impl.spec.ts
+++ b/packages/remix/src/generators/loader/loader.impl.spec.ts
@@ -19,7 +19,7 @@ describe('loader', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
   });
 
@@ -44,9 +44,7 @@ describe('loader', () => {
 
       it('should add imports', async () => {
         const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
-        expect(content).toMatch(
-          `import { json } from '@remix-run/node';`
-        );
+        expect(content).toMatch(`import { json } from '@remix-run/node';`);
         expect(content).toMatch(
           `import type { LoaderArgs } from '@remix-run/node';`
         );

--- a/packages/remix/src/generators/loader/loader.impl.spec.ts
+++ b/packages/remix/src/generators/loader/loader.impl.spec.ts
@@ -19,6 +19,7 @@ describe('loader', () => {
       loader: false,
       action: false,
       meta: false,
+      skipChecks: false
     });
   });
 

--- a/packages/remix/src/generators/loader/loader.impl.ts
+++ b/packages/remix/src/generators/loader/loader.impl.ts
@@ -1,10 +1,9 @@
 import { formatFiles, Tree } from '@nrwl/devkit';
-import { LoaderSchema } from './schema';
 import { insertImport } from '../../utils/insert-import';
 import { insertStatementAfterImports } from '../../utils/insert-statement-after-imports';
-import { getDefaultExportName } from '../../utils/get-default-export-name';
 import { insertStatementInDefaultFunction } from '../../utils/insert-statement-in-default-function';
 import { resolveRemixRouteFile } from '../../utils/remix-route-utils';
+import { LoaderSchema } from './schema';
 
 export default async function (tree: Tree, schema: LoaderSchema) {
   const routeFilePath = resolveRemixRouteFile(
@@ -21,7 +20,9 @@ export default async function (tree: Tree, schema: LoaderSchema) {
 
   insertImport(tree, routeFilePath, 'useLoaderData', '@remix-run/react');
   insertImport(tree, routeFilePath, 'json', '@remix-run/node');
-  insertImport(tree, routeFilePath, 'LoaderArgs', '@remix-run/node', {typeOnly: true});
+  insertImport(tree, routeFilePath, 'LoaderArgs', '@remix-run/node', {
+    typeOnly: true,
+  });
 
   insertStatementAfterImports(
     tree,

--- a/packages/remix/src/generators/loader/loader.impl.ts
+++ b/packages/remix/src/generators/loader/loader.impl.ts
@@ -19,33 +19,24 @@ export default async function (tree: Tree, schema: LoaderSchema) {
     );
   }
 
-  insertImport(tree, routeFilePath, 'LoaderFunction', '@remix-run/node', {
-    typeOnly: true,
-  });
   insertImport(tree, routeFilePath, 'useLoaderData', '@remix-run/react');
   insertImport(tree, routeFilePath, 'json', '@remix-run/node');
-
-  const defaultExportName = getDefaultExportName(tree, routeFilePath);
-  const loaderTypeName = `${defaultExportName}LoaderData`;
+  insertImport(tree, routeFilePath, 'LoaderArgs', '@remix-run/node', {typeOnly: true});
 
   insertStatementAfterImports(
     tree,
     routeFilePath,
     `
-    type ${loaderTypeName} = {
-        message: string;
-    };
-
-    export const loader: LoaderFunction = async () => {
+    export const loader = async ({request}: LoaderArgs ) => {
       return json({
         message: 'Hello, world!',
       })
     };
-    
+
     `
   );
 
-  const statement = `\nconst data = useLoaderData<${loaderTypeName}>();`;
+  const statement = `\nconst data = useLoaderData<typeof loader>();`;
 
   try {
     insertStatementInDefaultFunction(tree, routeFilePath, statement);

--- a/packages/remix/src/generators/meta/meta.impl.spec.ts
+++ b/packages/remix/src/generators/meta/meta.impl.spec.ts
@@ -19,7 +19,7 @@ describe('meta', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
   });
 

--- a/packages/remix/src/generators/meta/meta.impl.spec.ts
+++ b/packages/remix/src/generators/meta/meta.impl.spec.ts
@@ -19,6 +19,7 @@ describe('meta', () => {
       loader: false,
       action: false,
       meta: false,
+      skipChecks: false
     });
   });
 

--- a/packages/remix/src/generators/preset/preset.impl.ts
+++ b/packages/remix/src/generators/preset/preset.impl.ts
@@ -1,6 +1,6 @@
 import { formatFiles, GeneratorCallback, Tree } from '@nrwl/devkit';
 
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { runTasksInSerial } from '@nrwl/devkit';
 import applicationGenerator from '../application/application.impl';
 import setupGenerator from '../setup/setup.impl';
 import { normalizeOptions } from './lib/normalize-options';

--- a/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
@@ -1,17 +1,16 @@
-import {Tree} from '@nrwl/devkit';
-import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
+import { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import resourceRouteGenerator from './resource-route.impl';
-import routeGenerator from "../route/route.impl";
 
 describe('resource route', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     tree.write('.gitignore', `/node_modules/dist`);
 
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
   });
 
   it('should not create a component', async () => {
@@ -20,7 +19,7 @@ describe('resource route', () => {
       path: '/example/',
       action: false,
       loader: true,
-      skipChecks: false
+      skipChecks: false,
     });
     const fileContents = tree.read('apps/demo/app/routes/example.ts', 'utf-8');
     expect(fileContents).not.toMatch('export default function');
@@ -34,7 +33,7 @@ describe('resource route', () => {
           path: 'example',
           action: false,
           loader: false,
-          skipChecks: false
+          skipChecks: false,
         })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"The resource route generator requires either \`loader\` or \`action\` to be true"`
@@ -58,7 +57,7 @@ describe('resource route', () => {
         path: config.path,
         action: false,
         loader: true,
-        skipChecks: false
+        skipChecks: false,
       });
 
       expect(tree.exists('apps/demo/app/routes/example.ts')).toBeTruthy();
@@ -106,7 +105,6 @@ describe('resource route', () => {
   });
 
   it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
-
     await resourceRouteGenerator(tree, {
       project: 'demo',
       path: 'route1/..ts', // route.$withParams.tsx => route..tsx
@@ -135,8 +133,6 @@ describe('resource route', () => {
       skipChecks: true,
     });
 
-
     expect(tree.exists('apps/demo/app/routes/route3/.ts')).toBe(true);
-
   });
 });

--- a/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
@@ -1,16 +1,17 @@
-import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {Tree} from '@nrwl/devkit';
+import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import resourceRouteGenerator from './resource-route.impl';
+import routeGenerator from "../route/route.impl";
 
 describe('resource route', () => {
   let tree: Tree;
 
   beforeEach(async () => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
     tree.write('.gitignore', `/node_modules/dist`);
 
-    await applicationGenerator(tree, { name: 'demo' });
+    await applicationGenerator(tree, {name: 'demo'});
   });
 
   it('should not create a component', async () => {
@@ -19,6 +20,7 @@ describe('resource route', () => {
       path: '/example/',
       action: false,
       loader: true,
+      skipChecks: false
     });
     const fileContents = tree.read('apps/demo/app/routes/example.ts', 'utf-8');
     expect(fileContents).not.toMatch('export default function');
@@ -32,6 +34,7 @@ describe('resource route', () => {
           path: 'example',
           action: false,
           loader: false,
+          skipChecks: false
         })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"The resource route generator requires either \`loader\` or \`action\` to be true"`
@@ -55,9 +58,85 @@ describe('resource route', () => {
         path: config.path,
         action: false,
         loader: true,
+        skipChecks: false
       });
 
       expect(tree.exists('apps/demo/app/routes/example.ts')).toBeTruthy();
     });
+  });
+
+  it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
+    expect.assertions(3);
+
+    await resourceRouteGenerator(tree, {
+      project: 'demo',
+      path: 'route1/.ts', // route.$withParams.tsx => route..tsx
+      loader: true,
+      action: true,
+      skipChecks: false,
+    }).catch((e) =>
+      expect(e).toMatchInlineSnapshot(
+        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+      )
+    );
+
+    await resourceRouteGenerator(tree, {
+      project: 'demo',
+      path: 'route2//index.ts', // route/$withParams/index.tsx => route//index.tsx
+      loader: true,
+      action: true,
+      skipChecks: false,
+    }).catch((e) =>
+      expect(e).toMatchInlineSnapshot(
+        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+      )
+    );
+
+    await resourceRouteGenerator(tree, {
+      project: 'demo',
+      path: 'route3/.ts', // route/$withParams.tsx => route/.tsx
+      loader: true,
+      action: true,
+      skipChecks: false,
+    }).catch((e) =>
+      expect(e).toMatchInlineSnapshot(
+        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+      )
+    );
+  });
+
+  it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
+
+    await resourceRouteGenerator(tree, {
+      project: 'demo',
+      path: 'route1/..ts', // route.$withParams.tsx => route..tsx
+      loader: true,
+      action: true,
+      skipChecks: true,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route1/..ts')).toBe(true);
+
+    await resourceRouteGenerator(tree, {
+      project: 'demo',
+      path: 'route2//index.ts', // route/$withParams/index.tsx => route//index.tsx
+      loader: true,
+      action: true,
+      skipChecks: true,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route2/index.ts')).toBe(true);
+
+    await resourceRouteGenerator(tree, {
+      project: 'demo',
+      path: 'route3/.ts', // route/$withParams.tsx => route/.tsx
+      loader: true,
+      action: true,
+      skipChecks: true,
+    });
+
+
+    expect(tree.exists('apps/demo/app/routes/route3/.ts')).toBe(true);
+
   });
 });

--- a/packages/remix/src/generators/resource-route/resource-route.impl.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.ts
@@ -2,9 +2,15 @@ import { formatFiles, Tree } from '@nrwl/devkit';
 import { RemixRouteSchema } from './schema';
 import loaderGenerator from '../loader/loader.impl';
 import actionGenerator from '../action/action.impl';
-import { resolveRemixRouteFile } from '../../utils/remix-route-utils';
+import {checkRoutePathForErrors, resolveRemixRouteFile} from '../../utils/remix-route-utils';
 
 export default async function (tree: Tree, options: RemixRouteSchema) {
+  if (
+    !options.skipChecks && checkRoutePathForErrors(options.path)
+  ) {
+    throw new Error(`Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.`)
+  }
+
   const routeFilePath = resolveRemixRouteFile(
     tree,
     options.path,

--- a/packages/remix/src/generators/resource-route/resource-route.impl.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.ts
@@ -1,14 +1,17 @@
 import { formatFiles, Tree } from '@nrwl/devkit';
-import { RemixRouteSchema } from './schema';
-import loaderGenerator from '../loader/loader.impl';
+import {
+  checkRoutePathForErrors,
+  resolveRemixRouteFile,
+} from '../../utils/remix-route-utils';
 import actionGenerator from '../action/action.impl';
-import {checkRoutePathForErrors, resolveRemixRouteFile} from '../../utils/remix-route-utils';
+import loaderGenerator from '../loader/loader.impl';
+import { RemixRouteSchema } from './schema';
 
 export default async function (tree: Tree, options: RemixRouteSchema) {
-  if (
-    !options.skipChecks && checkRoutePathForErrors(options.path)
-  ) {
-    throw new Error(`Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.`)
+  if (!options.skipChecks && checkRoutePathForErrors(options.path)) {
+    throw new Error(
+      `Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.`
+    );
   }
 
   const routeFilePath = resolveRemixRouteFile(

--- a/packages/remix/src/generators/resource-route/schema.d.ts
+++ b/packages/remix/src/generators/resource-route/schema.d.ts
@@ -3,4 +3,5 @@ export interface RemixRouteSchema {
   path: string;
   action: boolean;
   loader: boolean;
+  skipChecks: boolean;
 }

--- a/packages/remix/src/generators/resource-route/schema.json
+++ b/packages/remix/src/generators/resource-route/schema.json
@@ -38,6 +38,11 @@
       "type": "boolean",
       "description": "Generate a loader function",
       "default": true
+    },
+    "skipChecks" : {
+      "type": "boolean",
+      "description": "Skip route error detection",
+      "default": false
     }
   },
   "required": ["project", "path"]

--- a/packages/remix/src/generators/resource-route/schema.json
+++ b/packages/remix/src/generators/resource-route/schema.json
@@ -39,7 +39,7 @@
       "description": "Generate a loader function",
       "default": true
     },
-    "skipChecks" : {
+    "skipChecks": {
       "type": "boolean",
       "description": "Skip route error detection",
       "default": false

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -1,5 +1,5 @@
-import { Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import {Tree} from '@nrwl/devkit';
+import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import routeGenerator from './route.impl';
 
@@ -7,12 +7,12 @@ describe('route', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
     tree.write('.gitignore', `/node_modules/dist`);
   });
 
   it('should add route component', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+    await applicationGenerator(tree, {name: 'demo'});
     await routeGenerator(tree, {
       project: 'demo',
       path: 'path/to/example',
@@ -20,6 +20,7 @@ describe('route', () => {
       loader: true,
       action: true,
       meta: true,
+      skipChecks: false,
     });
 
     const content = tree
@@ -33,7 +34,7 @@ describe('route', () => {
   });
 
   it('should support --style=none', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+    await applicationGenerator(tree, {name: 'demo'});
     await routeGenerator(tree, {
       project: 'demo',
       path: 'example',
@@ -41,6 +42,7 @@ describe('route', () => {
       loader: true,
       action: true,
       meta: true,
+      skipChecks: false,
     });
 
     const content = tree.read('apps/demo/app/routes/example.tsx').toString();
@@ -49,7 +51,7 @@ describe('route', () => {
   });
 
   it('should handle trailing and prefix slashes', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+    await applicationGenerator(tree, {name: 'demo'});
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/',
@@ -57,6 +59,7 @@ describe('route', () => {
       loader: true,
       action: true,
       meta: true,
+      skipChecks: false,
     });
 
     const content = tree.read('apps/demo/app/routes/example.tsx').toString();
@@ -64,7 +67,7 @@ describe('route', () => {
   });
 
   it('should handle routes that end in a file', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+    await applicationGenerator(tree, {name: 'demo'});
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/index.tsx',
@@ -72,6 +75,7 @@ describe('route', () => {
       loader: true,
       action: true,
       meta: true,
+      skipChecks: false,
     });
 
     const content = tree
@@ -81,7 +85,7 @@ describe('route', () => {
   });
 
   it('should handle routes that have a param', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+    await applicationGenerator(tree, {name: 'demo'});
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
@@ -89,11 +93,101 @@ describe('route', () => {
       loader: true,
       action: true,
       meta: true,
+      skipChecks: false,
     });
 
     const content = tree
       .read('apps/demo/app/routes/example/$withParam.tsx')
       .toString();
     expect(content).toMatch('function ExampleWithParam(');
+  });
+
+  it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+
+    expect.assertions(3);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route1/.tsx', // route.$withParams.tsx => route..tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    }).catch((e) =>
+      expect(e).toMatchInlineSnapshot(
+        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+      )
+    );
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route2//index.tsx', // route/$withParams/index.tsx => route//index.tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    }).catch((e) =>
+      expect(e).toMatchInlineSnapshot(
+        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+      )
+    );
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route3/.tsx', // route/$withParams.tsx => route/.tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    }).catch((e) =>
+      expect(e).toMatchInlineSnapshot(
+        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+      )
+    );
+  });
+
+  it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route1/..tsx', // route.$withParams.tsx => route..tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: true,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route1/..tsx')).toBe(true);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route2//index.tsx', // route/$withParams/index.tsx => route//index.tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: true,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route2/index.tsx')).toBe(true);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route3/.tsx', // route/$withParams.tsx => route/.tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: true,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route3/.tsx')).toBe(true);
+
   });
 });

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -291,7 +291,7 @@ describe('route', () => {
     expect(tree.exists('apps/demo/app/routes/route.using.v2.routing.tsx')).toBe(
       true
     );
-  });
+  }, 30000);
 
   it('should place the route correctly in a standalone app', async () => {
     await presetGenerator(tree, { name: 'demo' });

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -190,4 +190,31 @@ describe('route', () => {
     expect(tree.exists('apps/demo/app/routes/route3/.tsx')).toBe(true);
 
   });
+
+  it('should place routes correctly when app dir is changed', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+
+    tree.write('apps/demo/remix.config.js', `
+    /**
+     * @type {import('@remix-run/dev').AppConfig}
+     */
+    module.exports = {
+      ignoredRouteFiles: ["**/.*"],
+      appDirectory: "my-custom-dir",
+    };`);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route.tsx', // route/$withParams.tsx => route/.tsx
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('apps/demo/my-custom-dir/routes/route.tsx')).toBe(true);
+
+
+  })
 });

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -2,7 +2,7 @@ import {Tree} from '@nrwl/devkit';
 import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import routeGenerator from './route.impl';
-
+import presetGenerator  from '../preset/preset.impl';
 describe('route', () => {
   let tree: Tree;
 
@@ -205,7 +205,7 @@ describe('route', () => {
 
     await routeGenerator(tree, {
       project: 'demo',
-      path: 'route.tsx', // route/$withParams.tsx => route/.tsx
+      path: 'route.tsx',
       style: 'css',
       loader: true,
       action: true,
@@ -216,5 +216,86 @@ describe('route', () => {
     expect(tree.exists('apps/demo/my-custom-dir/routes/route.tsx')).toBe(true);
 
 
+  });
+
+  it('should normalize route paths', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'routeRelativeToRoutesDir.tsx',
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/routeRelativeToRoutesDir.tsx')).toBe(true);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'app/routes/routeRelativeToProjectRoot.tsx',
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/routeRelativeToProjectRoot.tsx')).toBe(true);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'apps/demo/app/routes/routeRelativeToWorkspaceRoot.tsx',
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/routeRelativeToWorkspaceRoot.tsx')).toBe(true);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'apps/demo/app/routes/route/using/v1/routing.tsx',
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route/using/v1/routing.tsx')).toBe(true);
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'apps/demo/app/routes/route.using.v2.routing.tsx',
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('apps/demo/app/routes/route.using.v2.routing.tsx')).toBe(true);
+
+  })
+
+  it('should place the route correctly in a standalone app', async () => {
+    await presetGenerator(tree, {name: 'demo'});
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route.tsx',
+      style: 'none',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+
+    expect(tree.exists('app/routes/route.tsx')).toBe(true);
   })
 });

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -216,6 +216,7 @@ describe('route', () => {
     });
 
     expect(tree.exists('apps/demo/my-custom-dir/routes/route.tsx')).toBe(true);
+    expect(tree.exists('apps/demo/my-custom-dir/styles/route.css')).toBe(true);
   });
 
   it('should normalize route paths', async () => {

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -79,4 +79,21 @@ describe('route', () => {
       .toString();
     expect(content).toMatch('function ExampleIndex(');
   });
+
+  it('should handle routes that have a param', async () => {
+    await applicationGenerator(tree, { name: 'demo' });
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+      style: 'css',
+      loader: true,
+      action: true,
+      meta: true,
+    });
+
+    const content = tree
+      .read('apps/demo/app/routes/example/$withParam.tsx')
+      .toString();
+    expect(content).toMatch('function ExampleWithParam(');
+  });
 });

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -1,18 +1,18 @@
-import {Tree} from '@nrwl/devkit';
-import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
+import { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
+import presetGenerator from '../preset/preset.impl';
 import routeGenerator from './route.impl';
-import presetGenerator  from '../preset/preset.impl';
 describe('route', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     tree.write('.gitignore', `/node_modules/dist`);
   });
 
   it('should add route component', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: 'path/to/example',
@@ -34,7 +34,7 @@ describe('route', () => {
   });
 
   it('should support --style=none', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: 'example',
@@ -51,7 +51,7 @@ describe('route', () => {
   });
 
   it('should handle trailing and prefix slashes', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/',
@@ -67,7 +67,7 @@ describe('route', () => {
   });
 
   it('should handle routes that end in a file', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/index.tsx',
@@ -85,7 +85,7 @@ describe('route', () => {
   });
 
   it('should handle routes that have a param', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
@@ -103,7 +103,7 @@ describe('route', () => {
   });
 
   it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
 
     expect.assertions(3);
 
@@ -151,7 +151,7 @@ describe('route', () => {
   });
 
   it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -188,20 +188,22 @@ describe('route', () => {
     });
 
     expect(tree.exists('apps/demo/app/routes/route3/.tsx')).toBe(true);
-
   });
 
   it('should place routes correctly when app dir is changed', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
 
-    tree.write('apps/demo/remix.config.js', `
+    tree.write(
+      'apps/demo/remix.config.js',
+      `
     /**
      * @type {import('@remix-run/dev').AppConfig}
      */
     module.exports = {
       ignoredRouteFiles: ["**/.*"],
       appDirectory: "my-custom-dir",
-    };`);
+    };`
+    );
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -214,12 +216,10 @@ describe('route', () => {
     });
 
     expect(tree.exists('apps/demo/my-custom-dir/routes/route.tsx')).toBe(true);
-
-
   });
 
   it('should normalize route paths', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -231,7 +231,9 @@ describe('route', () => {
       skipChecks: false,
     });
 
-    expect(tree.exists('apps/demo/app/routes/routeRelativeToRoutesDir.tsx')).toBe(true);
+    expect(
+      tree.exists('apps/demo/app/routes/routeRelativeToRoutesDir.tsx')
+    ).toBe(true);
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -243,7 +245,9 @@ describe('route', () => {
       skipChecks: false,
     });
 
-    expect(tree.exists('apps/demo/app/routes/routeRelativeToProjectRoot.tsx')).toBe(true);
+    expect(
+      tree.exists('apps/demo/app/routes/routeRelativeToProjectRoot.tsx')
+    ).toBe(true);
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -255,7 +259,9 @@ describe('route', () => {
       skipChecks: false,
     });
 
-    expect(tree.exists('apps/demo/app/routes/routeRelativeToWorkspaceRoot.tsx')).toBe(true);
+    expect(
+      tree.exists('apps/demo/app/routes/routeRelativeToWorkspaceRoot.tsx')
+    ).toBe(true);
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -267,7 +273,9 @@ describe('route', () => {
       skipChecks: false,
     });
 
-    expect(tree.exists('apps/demo/app/routes/route/using/v1/routing.tsx')).toBe(true);
+    expect(tree.exists('apps/demo/app/routes/route/using/v1/routing.tsx')).toBe(
+      true
+    );
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -279,12 +287,13 @@ describe('route', () => {
       skipChecks: false,
     });
 
-    expect(tree.exists('apps/demo/app/routes/route.using.v2.routing.tsx')).toBe(true);
-
-  })
+    expect(tree.exists('apps/demo/app/routes/route.using.v2.routing.tsx')).toBe(
+      true
+    );
+  });
 
   it('should place the route correctly in a standalone app', async () => {
-    await presetGenerator(tree, {name: 'demo'});
+    await presetGenerator(tree, { name: 'demo' });
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -297,5 +306,5 @@ describe('route', () => {
     });
 
     expect(tree.exists('app/routes/route.tsx')).toBe(true);
-  })
+  });
 });

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -6,16 +6,22 @@ import {
   stripIndents,
   Tree,
 } from '@nrwl/devkit';
-import { RemixRouteSchema } from './schema';
+import {RemixRouteSchema} from './schema';
 import LoaderGenerator from '../loader/loader.impl';
 import MetaGenerator from '../meta/meta.impl';
 import ActionGenerator from '../action/action.impl';
 import StyleGenerator from '../style/style.impl';
-import { resolveRemixRouteFile } from '../../utils/remix-route-utils';
+import {checkRoutePathForErrors, resolveRemixRouteFile} from '../../utils/remix-route-utils';
 
 export default async function (tree: Tree, options: RemixRouteSchema) {
   const project = readProjectConfiguration(tree, options.project);
   if (!project) throw new Error(`Project does not exist: ${options.project}`);
+
+  if (
+    !options.skipChecks && checkRoutePathForErrors(options.path)
+  ) {
+    throw new Error(`Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.`)
+  }
 
   const routeFilePath = resolveRemixRouteFile(
     tree,
@@ -24,7 +30,7 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
     '.tsx'
   );
 
-  const { className: componentName } = names(
+  const {className: componentName} = names(
     options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '')
   );
 

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -1,26 +1,28 @@
 import {
   formatFiles,
-  joinPathFragments,
   names,
   readProjectConfiguration,
   stripIndents,
   Tree,
 } from '@nrwl/devkit';
-import {RemixRouteSchema} from './schema';
+import {
+  checkRoutePathForErrors,
+  resolveRemixRouteFile,
+} from '../../utils/remix-route-utils';
+import ActionGenerator from '../action/action.impl';
 import LoaderGenerator from '../loader/loader.impl';
 import MetaGenerator from '../meta/meta.impl';
-import ActionGenerator from '../action/action.impl';
 import StyleGenerator from '../style/style.impl';
-import {checkRoutePathForErrors, resolveRemixRouteFile} from '../../utils/remix-route-utils';
+import { RemixRouteSchema } from './schema';
 
 export default async function (tree: Tree, options: RemixRouteSchema) {
   const project = readProjectConfiguration(tree, options.project);
   if (!project) throw new Error(`Project does not exist: ${options.project}`);
 
-  if (
-    !options.skipChecks && checkRoutePathForErrors(options.path)
-  ) {
-    throw new Error(`Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.`)
+  if (!options.skipChecks && checkRoutePathForErrors(options.path)) {
+    throw new Error(
+      `Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.`
+    );
   }
 
   const routeFilePath = resolveRemixRouteFile(
@@ -30,7 +32,7 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
     '.tsx'
   );
 
-  const {className: componentName} = names(
+  const { className: componentName } = names(
     options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '')
   );
 

--- a/packages/remix/src/generators/route/schema.d.ts
+++ b/packages/remix/src/generators/route/schema.d.ts
@@ -5,4 +5,5 @@ export interface RemixRouteSchema {
   action: boolean;
   meta: boolean;
   loader: boolean;
+  skipChecks: boolean;
 }

--- a/packages/remix/src/generators/route/schema.json
+++ b/packages/remix/src/generators/route/schema.json
@@ -50,7 +50,7 @@
       "description": "Generate a loader function",
       "default": false
     },
-    "skipChecks" : {
+    "skipChecks": {
       "type": "boolean",
       "description": "Skip route error detection",
       "default": false

--- a/packages/remix/src/generators/route/schema.json
+++ b/packages/remix/src/generators/route/schema.json
@@ -49,6 +49,11 @@
       "type": "boolean",
       "description": "Generate a loader function",
       "default": false
+    },
+    "skipChecks" : {
+      "type": "boolean",
+      "description": "Skip route error detection",
+      "default": false
     }
   },
   "required": ["project", "path"]

--- a/packages/remix/src/generators/setup/setup.impl.ts
+++ b/packages/remix/src/generators/setup/setup.impl.ts
@@ -1,6 +1,6 @@
 import { formatFiles, GeneratorCallback, Tree } from '@nrwl/devkit';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { runTasksInSerial } from '@nrwl/devkit';
 
 export default async function (tree: Tree) {
   const tasks: GeneratorCallback[] = [];

--- a/packages/remix/src/generators/setup/setup.impl.ts
+++ b/packages/remix/src/generators/setup/setup.impl.ts
@@ -1,6 +1,10 @@
-import { formatFiles, GeneratorCallback, Tree } from '@nrwl/devkit';
+import {
+  formatFiles,
+  GeneratorCallback,
+  runTasksInSerial,
+  Tree,
+} from '@nrwl/devkit';
 import { initGenerator as jsInitGenerator } from '@nrwl/js';
-import { runTasksInSerial } from '@nrwl/devkit';
 
 export default async function (tree: Tree) {
   const tasks: GeneratorCallback[] = [];

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -1,0 +1,56 @@
+import {Tree} from '@nrwl/devkit';
+import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
+import applicationGenerator from '../application/application.impl';
+import routeGenerator from '../route/route.impl';
+import styleGenerator from './style.impl';
+
+describe('route', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
+    tree.write('.gitignore', `/node_modules/dist`);
+  });
+
+  it('should add css file to shared styles directory', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'path/to/example',
+      style: 'none',
+      loader: false,
+      action: false,
+      meta: false,
+    });
+    await styleGenerator(tree, {
+      project: 'demo',
+      path: 'path/to/example'
+    })
+
+    expect(
+      tree.exists('apps/demo/app/styles/path/to/example.css')
+    ).toBeTruthy();
+  });
+
+  it('should handle routes that have a param', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+      style: 'none',
+      loader: false,
+      action: false,
+      meta: false,
+    });
+    await styleGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+    })
+
+    expect(
+      tree.exists('apps/demo/app/styles/example/$withParam.css')
+    ).toBeTruthy();
+  });
+  
+
+});

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -1,20 +1,20 @@
-import {Tree} from '@nrwl/devkit';
-import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
+import { Tree } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
+import presetGenerator from '../preset/preset.impl';
 import routeGenerator from '../route/route.impl';
 import styleGenerator from './style.impl';
-import presetGenerator from "../preset/preset.impl";
 
 describe('route', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace({layout: 'apps-libs'});
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     tree.write('.gitignore', `/node_modules/dist`);
   });
 
   it('should add css file to shared styles directory', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: 'path/to/example',
@@ -22,12 +22,12 @@ describe('route', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
     await styleGenerator(tree, {
       project: 'demo',
-      path: 'path/to/example'
-    })
+      path: 'path/to/example',
+    });
 
     expect(
       tree.exists('apps/demo/app/styles/path/to/example.css')
@@ -35,7 +35,7 @@ describe('route', () => {
   });
 
   it('should handle routes that have a param', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
@@ -43,12 +43,12 @@ describe('route', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
     await styleGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
-    })
+    });
 
     expect(
       tree.exists('apps/demo/app/styles/example/$withParam.css')
@@ -56,7 +56,7 @@ describe('route', () => {
   });
 
   it('should import stylesheet with a relative path in an integrated workspace', async () => {
-    await applicationGenerator(tree, {name: 'demo'});
+    await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
@@ -64,20 +64,24 @@ describe('route', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
     await styleGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
-    })
-    const content = tree.read("apps/demo/app/routes/example/$withParam.tsx", "utf-8");
+    });
+    const content = tree.read(
+      'apps/demo/app/routes/example/$withParam.tsx',
+      'utf-8'
+    );
 
-    expect(content).toMatch("import stylesUrl from '../../styles/example/$withParam.css';");
+    expect(content).toMatch(
+      "import stylesUrl from '../../styles/example/$withParam.css';"
+    );
   });
 
   it('should import stylesheet using ~ in a standalone project', async () => {
-
-    await presetGenerator(tree, {name: 'demo'});
+    await presetGenerator(tree, { name: 'demo' });
 
     await routeGenerator(tree, {
       project: 'demo',
@@ -86,17 +90,17 @@ describe('route', () => {
       loader: false,
       action: false,
       meta: false,
-      skipChecks: false
+      skipChecks: false,
     });
 
     await styleGenerator(tree, {
       project: 'demo',
       path: '/example/$withParam.tsx',
-    })
-    const content = tree.read("app/routes/example/$withParam.tsx", "utf-8");
+    });
+    const content = tree.read('app/routes/example/$withParam.tsx', 'utf-8');
 
-    expect(content).toMatch("import stylesUrl from '~/styles/example/$withParam.css';");
-  })
-
-
+    expect(content).toMatch(
+      "import stylesUrl from '~/styles/example/$withParam.css';"
+    );
+  });
 });

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -21,6 +21,7 @@ describe('route', () => {
       loader: false,
       action: false,
       meta: false,
+      skipChecks: false
     });
     await styleGenerator(tree, {
       project: 'demo',
@@ -41,6 +42,7 @@ describe('route', () => {
       loader: false,
       action: false,
       meta: false,
+      skipChecks: false
     });
     await styleGenerator(tree, {
       project: 'demo',
@@ -51,6 +53,6 @@ describe('route', () => {
       tree.exists('apps/demo/app/styles/example/$withParam.css')
     ).toBeTruthy();
   });
-  
+
 
 });

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -3,6 +3,7 @@ import {createTreeWithEmptyWorkspace} from '@nrwl/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import routeGenerator from '../route/route.impl';
 import styleGenerator from './style.impl';
+import presetGenerator from "../preset/preset.impl";
 
 describe('route', () => {
   let tree: Tree;
@@ -53,6 +54,49 @@ describe('route', () => {
       tree.exists('apps/demo/app/styles/example/$withParam.css')
     ).toBeTruthy();
   });
+
+  it('should import stylesheet with a relative path in an integrated workspace', async () => {
+    await applicationGenerator(tree, {name: 'demo'});
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+      style: 'none',
+      loader: false,
+      action: false,
+      meta: false,
+      skipChecks: false
+    });
+    await styleGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+    })
+    const content = tree.read("apps/demo/app/routes/example/$withParam.tsx", "utf-8");
+
+    expect(content).toMatch("import stylesUrl from '../../styles/example/$withParam.css';");
+  });
+
+  it('should import stylesheet using ~ in a standalone project', async () => {
+
+    await presetGenerator(tree, {name: 'demo'});
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+      style: 'none',
+      loader: false,
+      action: false,
+      meta: false,
+      skipChecks: false
+    });
+
+    await styleGenerator(tree, {
+      project: 'demo',
+      path: '/example/$withParam.tsx',
+    })
+    const content = tree.read("app/routes/example/$withParam.tsx", "utf-8");
+
+    expect(content).toMatch("import stylesUrl from '~/styles/example/$withParam.css';");
+  })
 
 
 });

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -55,6 +55,38 @@ describe('route', () => {
     ).toBeTruthy();
   });
 
+  it('should place styles correctly when app dir is changed', async () => {
+    await applicationGenerator(tree, { name: 'demo' });
+
+    tree.write(
+      'apps/demo/remix.config.js',
+      `
+    /**
+     * @type {import('@remix-run/dev').AppConfig}
+     */
+    module.exports = {
+      ignoredRouteFiles: ["**/.*"],
+      appDirectory: "my-custom-dir",
+    };`
+    );
+
+    await routeGenerator(tree, {
+      project: 'demo',
+      path: 'route.tsx',
+      style: 'none',
+      loader: true,
+      action: true,
+      meta: true,
+      skipChecks: false,
+    });
+    await styleGenerator(tree, {
+      project: 'demo',
+      path: '/route.tsx',
+    });
+
+    expect(tree.exists('apps/demo/my-custom-dir/styles/route.css')).toBe(true);
+  });
+
   it('should import stylesheet with a relative path in an integrated workspace', async () => {
     await applicationGenerator(tree, { name: 'demo' });
     await routeGenerator(tree, {

--- a/packages/remix/src/generators/style/style.impl.ts
+++ b/packages/remix/src/generators/style/style.impl.ts
@@ -6,18 +6,18 @@ import {
   stripIndents,
   Tree,
 } from '@nrwl/devkit';
-import {RemixStyleSchema} from './schema';
+import { RemixStyleSchema } from './schema';
 
-import {insertImport} from '../../utils/insert-import';
-import {insertStatementAfterImports} from '../../utils/insert-statement-after-imports';
+import { dirname, relative } from 'path';
+import { insertImport } from '../../utils/insert-import';
+import { insertStatementAfterImports } from '../../utils/insert-statement-after-imports';
 import {
   normalizeRoutePath,
   resolveRemixRouteFile,
 } from '../../utils/remix-route-utils';
-import {relative, dirname} from 'path';
 
 export default async function (tree: Tree, options: RemixStyleSchema) {
-  const {name: routePath} = names(
+  const { name: routePath } = names(
     options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '')
   );
 
@@ -82,7 +82,6 @@ export default async function (tree: Tree, options: RemixStyleSchema) {
   `
     );
   }
-
 
   await formatFiles(tree);
 }

--- a/packages/remix/src/generators/style/style.impl.ts
+++ b/packages/remix/src/generators/style/style.impl.ts
@@ -13,6 +13,7 @@ import { insertImport } from '../../utils/insert-import';
 import { insertStatementAfterImports } from '../../utils/insert-statement-after-imports';
 import {
   normalizeRoutePath,
+  resolveRemixAppDirectory,
   resolveRemixRouteFile,
 } from '../../utils/remix-route-utils';
 
@@ -27,8 +28,8 @@ export default async function (tree: Tree, options: RemixStyleSchema) {
   const normalizedRoutePath = normalizeRoutePath(routePath);
 
   const stylesheetPath = joinPathFragments(
-    project.root,
-    'app/styles',
+    resolveRemixAppDirectory(tree, project.name),
+    'styles',
     `${normalizedRoutePath}.css`
   );
 

--- a/packages/remix/src/generators/style/style.impl.ts
+++ b/packages/remix/src/generators/style/style.impl.ts
@@ -16,7 +16,7 @@ import {
 } from '../../utils/remix-route-utils';
 
 export default async function (tree: Tree, options: RemixStyleSchema) {
-  const { fileName: routePath, className: componentName } = names(
+  const { name: routePath } = names(
     options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '')
   );
 
@@ -61,7 +61,7 @@ export default async function (tree: Tree, options: RemixStyleSchema) {
     routeFilePath,
     `
     import stylesUrl from '~/styles/${normalizedRoutePath}.css'
-    
+
     export const links: LinksFunction = () => {
       return [{ rel: 'stylesheet', href: stylesUrl }];
     };

--- a/packages/remix/src/generators/style/style.impl.ts
+++ b/packages/remix/src/generators/style/style.impl.ts
@@ -6,24 +6,25 @@ import {
   stripIndents,
   Tree,
 } from '@nrwl/devkit';
-import { RemixStyleSchema } from './schema';
+import {RemixStyleSchema} from './schema';
 
-import { insertImport } from '../../utils/insert-import';
-import { insertStatementAfterImports } from '../../utils/insert-statement-after-imports';
+import {insertImport} from '../../utils/insert-import';
+import {insertStatementAfterImports} from '../../utils/insert-statement-after-imports';
 import {
   normalizeRoutePath,
   resolveRemixRouteFile,
 } from '../../utils/remix-route-utils';
+import {relative, dirname} from 'path';
 
 export default async function (tree: Tree, options: RemixStyleSchema) {
-  const { name: routePath } = names(
+  const {name: routePath} = names(
     options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '')
   );
 
   const project = readProjectConfiguration(tree, options.project);
   if (!project) throw new Error(`Project does not exist: ${options.project}`);
 
-  const normalizedRoutePath = normalizeRoutePath(routePath, project.root);
+  const normalizedRoutePath = normalizeRoutePath(routePath);
 
   const stylesheetPath = joinPathFragments(
     project.root,
@@ -56,17 +57,32 @@ export default async function (tree: Tree, options: RemixStyleSchema) {
     typeOnly: true,
   });
 
-  insertStatementAfterImports(
-    tree,
-    routeFilePath,
-    `
+  if (project.root === '.') {
+    insertStatementAfterImports(
+      tree,
+      routeFilePath,
+      `
     import stylesUrl from '~/styles/${normalizedRoutePath}.css'
 
     export const links: LinksFunction = () => {
       return [{ rel: 'stylesheet', href: stylesUrl }];
     };
   `
-  );
+    );
+  } else {
+    insertStatementAfterImports(
+      tree,
+      routeFilePath,
+      `
+    import stylesUrl from '${relative(dirname(routeFilePath), stylesheetPath)}';
+
+    export const links: LinksFunction = () => {
+      return [{ rel: 'stylesheet', href: stylesUrl }];
+    };
+  `
+    );
+  }
+
 
   await formatFiles(tree);
 }

--- a/packages/remix/src/migrations/update-14-5-4/update-tsconfig-and-remix-config-for-1-6-8.spec.ts
+++ b/packages/remix/src/migrations/update-14-5-4/update-tsconfig-and-remix-config-for-1-6-8.spec.ts
@@ -123,8 +123,7 @@ describe('Update app tsconfig.json', () => {
       sourceRoot: 'apps/not-remix/src',
     });
 
-    const notRemixTsConfigJson =
-`{
+    const notRemixTsConfigJson = `{
   "extends": "../../../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/packages/remix/src/migrations/update-14-5-4/update-tsconfig-and-remix-config-for-1-6-8.spec.ts
+++ b/packages/remix/src/migrations/update-14-5-4/update-tsconfig-and-remix-config-for-1-6-8.spec.ts
@@ -9,7 +9,7 @@ import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 
 import update from './update-tsconfig-and-remix-config-for-1-6-8';
 
-xdescribe('Update remix.config', () => {
+describe('Update remix.config', () => {
   it('should add watchPaths', async () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     createLegacyRemixApp(tree, 'remix', 'apps/remix');
@@ -81,7 +81,7 @@ xdescribe('Update remix.config', () => {
   });
 });
 
-xdescribe('Update app tsconfig.json', () => {
+describe('Update app tsconfig.json', () => {
   it('should remove `basePath`', async () => {
     const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     createLegacyRemixApp(tree, 'remix', 'apps/remix');
@@ -123,32 +123,33 @@ xdescribe('Update app tsconfig.json', () => {
       sourceRoot: 'apps/not-remix/src',
     });
 
-    const notRemixTsConfigJson = `
-          {
-            "extends": "../../../../tsconfig.base.json",
-            "compilerOptions": {
-              "jsx": "react-jsx",
-              "allowJs": true,
-              "esModuleInterop": true,
-              "allowSyntheticDefaultImports": true,
-              "forceConsistentCasingInFileNames": true,
-              "strict": true,
-              "noImplicitOverride": true,
-              "noPropertyAccessFromIndexSignature": true,
-              "noImplicitReturns": true,
-              "noFallthroughCasesInSwitch": true
-            },
-            "files": [],
-            "include": [],
-            "references": [
-              {
-                "path": "./tsconfig.app.json"
-              },
-              {
-                "path": "./tsconfig.spec.json"
-              }
-            ]
-          }`;
+    const notRemixTsConfigJson =
+`{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}
+`;
 
     tree.write('apps/not-remix/tsconfig.json', notRemixTsConfigJson);
 

--- a/packages/remix/src/utils/remix-route-utils.ts
+++ b/packages/remix/src/utils/remix-route-utils.ts
@@ -47,8 +47,8 @@ export function resolveRemixRouteFile(
   const fileName = normalizedRoutePath.endsWith(fileExtension)
     ? normalizedRoutePath
     : `${normalizedRoutePath}${fileExtension}`;
-  // TODO: what if someone changes the Remix app root folder in the remix.config.js?
-  const routeFilePath = joinPathFragments(project.root, 'app/routes', fileName);
+
+  const routeFilePath = joinPathFragments(resolveRemixAppDirectory(tree,projectName), 'routes', fileName);
   return routeFilePath;
 }
 
@@ -65,4 +65,15 @@ export function checkRoutePathForErrors(path: string) {
     path.match(/\w\/\/\w/) || // route/$withParams/index.tsx => route//index.tsx
     path.match(/\w\/\.\w/) // route/$withParams.tsx => route/.tsx
   )
+}
+
+export function resolveRemixAppDirectory(tree: Tree, projectName: string) {
+  const project = readProjectConfiguration(tree, projectName);
+  if (!project) throw new Error(`Project does not exist: ${projectName}`);
+
+  const remixConfigPath = joinPathFragments(project.root, 'remix.config.js');
+
+  const remixConfig = eval(tree.read(remixConfigPath,"utf-8"));
+
+  return joinPathFragments(project.root, remixConfig.appDirectory ?? 'app')
 }

--- a/packages/remix/src/utils/remix-route-utils.ts
+++ b/packages/remix/src/utils/remix-route-utils.ts
@@ -21,7 +21,7 @@ export function resolveRemixRouteFile(
 ): string {
   const project = readProjectConfiguration(tree, projectName);
   if (!project) throw new Error(`Project does not exist: ${projectName}`);
-  const { name: routePath } = names(
+  const {name: routePath} = names(
     path.replace(/^\//, '').replace(/\/$/, '')
   );
   const normalizedRoutePath = normalizeRoutePath(routePath, project.root);
@@ -57,4 +57,12 @@ export function normalizeRoutePath(path: string, projectRoot: string) {
   if (path.indexOf('/routes/') > -1)
     return path.substring(path.indexOf('/routes/') + 8);
   return path.substring(projectRoot.length + 1);
+}
+
+export function checkRoutePathForErrors(path: string) {
+  return (
+    path.match(/\w\.\.\w/) || // route.$withParams.tsx => route..tsx
+    path.match(/\w\/\/\w/) || // route/$withParams/index.tsx => route//index.tsx
+    path.match(/\w\/\.\w/) // route/$withParams.tsx => route/.tsx
+  )
 }

--- a/packages/remix/src/utils/remix-route-utils.ts
+++ b/packages/remix/src/utils/remix-route-utils.ts
@@ -21,7 +21,7 @@ export function resolveRemixRouteFile(
 ): string {
   const project = readProjectConfiguration(tree, projectName);
   if (!project) throw new Error(`Project does not exist: ${projectName}`);
-  const { fileName: routePath } = names(
+  const { name: routePath } = names(
     path.replace(/^\//, '').replace(/\/$/, '')
   );
   const normalizedRoutePath = normalizeRoutePath(routePath, project.root);

--- a/packages/remix/src/utils/remix-route-utils.ts
+++ b/packages/remix/src/utils/remix-route-utils.ts
@@ -21,9 +21,7 @@ export function resolveRemixRouteFile(
 ): string {
   const project = readProjectConfiguration(tree, projectName);
   if (!project) throw new Error(`Project does not exist: ${projectName}`);
-  const {name: routePath} = names(
-    path.replace(/^\//, '').replace(/\/$/, '')
-  );
+  const { name: routePath } = names(path.replace(/^\//, '').replace(/\/$/, ''));
   const normalizedRoutePath = normalizeRoutePath(routePath);
 
   // if no file extension specified, let's try to find it
@@ -48,11 +46,17 @@ export function resolveRemixRouteFile(
     ? normalizedRoutePath
     : `${normalizedRoutePath}${fileExtension}`;
 
-  return joinPathFragments(resolveRemixAppDirectory(tree,projectName), 'routes', fileName);
+  return joinPathFragments(
+    resolveRemixAppDirectory(tree, projectName),
+    'routes',
+    fileName
+  );
 }
 
 export function normalizeRoutePath(path: string) {
-  return path.indexOf('/routes/') > -1 ? path.substring(path.indexOf('/routes/') + 8) : path;
+  return path.indexOf('/routes/') > -1
+    ? path.substring(path.indexOf('/routes/') + 8)
+    : path;
 }
 
 export function checkRoutePathForErrors(path: string) {
@@ -60,7 +64,7 @@ export function checkRoutePathForErrors(path: string) {
     path.match(/\w\.\.\w/) || // route.$withParams.tsx => route..tsx
     path.match(/\w\/\/\w/) || // route/$withParams/index.tsx => route//index.tsx
     path.match(/\w\/\.\w/) // route/$withParams.tsx => route/.tsx
-  )
+  );
 }
 
 export function resolveRemixAppDirectory(tree: Tree, projectName: string) {
@@ -69,7 +73,7 @@ export function resolveRemixAppDirectory(tree: Tree, projectName: string) {
 
   const remixConfigPath = joinPathFragments(project.root, 'remix.config.js');
 
-  const remixConfig = eval(tree.read(remixConfigPath,"utf-8"));
+  const remixConfig = eval(tree.read(remixConfigPath, 'utf-8'));
 
-  return joinPathFragments(project.root, remixConfig.appDirectory ?? 'app')
+  return joinPathFragments(project.root, remixConfig.appDirectory ?? 'app');
 }

--- a/packages/remix/src/utils/remix-route-utils.ts
+++ b/packages/remix/src/utils/remix-route-utils.ts
@@ -24,7 +24,7 @@ export function resolveRemixRouteFile(
   const {name: routePath} = names(
     path.replace(/^\//, '').replace(/\/$/, '')
   );
-  const normalizedRoutePath = normalizeRoutePath(routePath, project.root);
+  const normalizedRoutePath = normalizeRoutePath(routePath);
 
   // if no file extension specified, let's try to find it
   if (!fileExtension) {
@@ -48,15 +48,11 @@ export function resolveRemixRouteFile(
     ? normalizedRoutePath
     : `${normalizedRoutePath}${fileExtension}`;
 
-  const routeFilePath = joinPathFragments(resolveRemixAppDirectory(tree,projectName), 'routes', fileName);
-  return routeFilePath;
+  return joinPathFragments(resolveRemixAppDirectory(tree,projectName), 'routes', fileName);
 }
 
-export function normalizeRoutePath(path: string, projectRoot: string) {
-  if (path.indexOf(projectRoot) === -1) return path;
-  if (path.indexOf('/routes/') > -1)
-    return path.substring(path.indexOf('/routes/') + 8);
-  return path.substring(projectRoot.length + 1);
+export function normalizeRoutePath(path: string) {
+  return path.indexOf('/routes/') > -1 ? path.substring(path.indexOf('/routes/') + 8) : path;
 }
 
 export function checkRoutePathForErrors(path: string) {


### PR DESCRIPTION
This PR adds some quality of life improvements to the Remix generators:

* Generators now generate code closer to the typing standards of the Remix community:
```typescript
const data = useLoaderData<typeof loader>();

// instead of

const data = useLoaderData<LoaderDataInterface>();
```
* Route params are no longer changed from camel-case to snake-case
* Route paths are checked for the very common error of an un-escaped `$`. The `$` is used in Remix for route params, but it's used for interpolation by many shells.
* The path to the Remix app directory is now resolved correctly if it has been changed in `remix.config.ts`
* Generators have been updated for better compatibility with standalone and integrated workspace
* More test and e2e coverage for Remix plugin
* Fixes the `cypress` generator by adding a fix for https://github.com/remix-run/remix/issues/5569 so that the first test passes