### PR TITLE
fix(rspack): do not force cssmodules

### DIFF
--- a/packages/rspack/src/utils/with-nx.ts
+++ b/packages/rspack/src/utils/with-nx.ts
@@ -68,14 +68,7 @@ export function withNx(_opts = {}) {
         port: 4200,
         hot: true,
       } as any,
-      module: {
-        rules: [
-          {
-            test: /\.css$/,
-            type: 'css/module' as any,
-          },
-        ],
-      },
+      module: {},
       plugins: config.plugins ?? [],
       resolve: {
         alias,

--- a/packages/rspack/src/utils/with-react.ts
+++ b/packages/rspack/src/utils/with-react.ts
@@ -10,7 +10,10 @@ export function withReact(opts = {}) {
     const isDev =
       process.env.NODE_ENV === 'development' || options.mode === 'development';
 
-    config = withWeb(opts)(config, { options, context });
+    config = withWeb({ ...opts, cssModules: true })(config, {
+      options,
+      context,
+    });
 
     return {
       ...config,

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -6,6 +6,7 @@ export interface WithWebOptions {
   stylePreprocessorOptions?: {
     includePaths?: string[];
   };
+  cssModules?: boolean;
 }
 
 export function withWeb(opts: WithWebOptions = {}) {
@@ -45,11 +46,11 @@ export function withWeb(opts: WithWebOptions = {}) {
           ...(config.module.rules || []),
           {
             test: /\.css$/,
-            type: 'css/module',
+            type: opts?.cssModules ? 'css/module' : undefined,
           },
           {
             test: /\.scss$|\.sass$/,
-            type: 'css/module',
+            type: opts?.cssModules ? 'css/module' : undefined,
             use: [
               {
                 loader: require.resolve('sass-loader'),
@@ -67,7 +68,7 @@ export function withWeb(opts: WithWebOptions = {}) {
           },
           {
             test: /.less$/,
-            type: 'css/module',
+            type: opts?.cssModules ? 'css/module' : undefined,
             use: [
               {
                 loader: require.resolve('less-loader'),


### PR DESCRIPTION
We would hardcode `css/module` on all styles files (.css, .scss, etc.). This results in web-components apps (or any project that's using plain css and not css modules) not getting the styles, due to the class name mangling. Let's only pass this rule optionally, and if the project is React.