### PR TITLE
chore(repo): clean up post rescope work

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -19,7 +19,7 @@ describe('remix e2e', () => {
     runNxCommandAsync('reset');
   });
 
-  fit('should create a standalone remix app', async () => {
+  it('should create a standalone remix app', async () => {
     const appName = uniq('remix');
     await runNxCommandAsync(
       `generate @nx/remix:preset --name ${appName} --verbose`

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -1,23 +1,10 @@
-import actionGenerator from './generators/action/action.impl';
-import applicationGenerator from './generators/application/application.impl';
-import cypressGenerator from './generators/cypress/cypress.impl';
-import libraryGenerator from './generators/library/library.impl';
-import loaderGenerator from './generators/loader/loader.impl';
-import metaGenerator from './generators/meta/meta.impl';
-import presetGenerator from './generators/preset/preset.impl';
-import resourceRouteGenerator from './generators/resource-route/resource-route.impl';
-import routerGenerator from './generators/route/route.impl';
-import styleGenerator from './generators/style/style.impl';
-
-export {
-  actionGenerator,
-  applicationGenerator,
-  cypressGenerator,
-  libraryGenerator,
-  loaderGenerator,
-  metaGenerator,
-  presetGenerator,
-  resourceRouteGenerator,
-  routerGenerator,
-  styleGenerator,
-};
+export * from './generators/action/action.impl';
+export * from './generators/application/application.impl';
+export * from './generators/cypress/cypress.impl';
+export * from './generators/library/library.impl';
+export * from './generators/loader/loader.impl';
+export * from './generators/meta/meta.impl';
+export * from './generators/preset/preset.impl';
+export * from './generators/resource-route/resource-route.impl';
+export * from './generators/route/route.impl';
+export * from './generators/style/style.impl';


### PR DESCRIPTION
the migrations did bulk of the work. 
just 1 spot where we'd want to have nrwl + nx package names in the deno graph plugin.

cleans up the index.ts of remix bc idk why I didn't use the `export *` syntax.

reenabled remix e2e tests.