### PR TITLE
fix(remix): library generator should create server entrypoint

### DIFF
--- a/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
+++ b/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
@@ -1,0 +1,35 @@
+import type { Tree } from '@nx/devkit';
+import {
+  joinPathFragments,
+  readProjectConfiguration,
+  updateJson,
+} from '@nx/devkit';
+import { getRootTsConfigPathInTree } from '@nx/js';
+import type { RemixLibraryOptions } from './normalize-options';
+
+export function addTsconfigEntryPoints(
+  tree: Tree,
+  options: RemixLibraryOptions
+) {
+  const { sourceRoot } = readProjectConfiguration(tree, options.projectName);
+  const serverFilePath = joinPathFragments(sourceRoot, 'server.ts');
+
+  tree.write(
+    serverFilePath,
+    `// This file should be used to export ONLY server-code from the library.`
+  );
+
+  const baseTsConfig = getRootTsConfigPathInTree(tree);
+  updateJson(tree, baseTsConfig, (json) => {
+    if (
+      json.compilerOptions.paths &&
+      json.compilerOptions.paths[options.importPath]
+    ) {
+      json.compilerOptions.paths[
+        joinPathFragments(options.importPath, 'server')
+      ] = [serverFilePath];
+    }
+
+    return json;
+  });
+}

--- a/packages/remix/src/generators/library/lib/index.ts
+++ b/packages/remix/src/generators/library/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './add-tsconfig-entry-points';
+export * from './normalize-options';
+export * from './update-buildable-config';

--- a/packages/remix/src/generators/library/lib/normalize-options.ts
+++ b/packages/remix/src/generators/library/lib/normalize-options.ts
@@ -1,0 +1,39 @@
+import type { Tree } from '@nx/devkit';
+import {
+  extractLayoutDirectory,
+  getImportPath,
+  getWorkspaceLayout,
+  names,
+} from '@nx/devkit';
+import {
+  normalizeDirectory,
+  normalizeProjectName,
+} from '../../../utils/project';
+import type { NxRemixGeneratorSchema } from '../schema';
+
+export interface RemixLibraryOptions extends NxRemixGeneratorSchema {
+  projectName: string;
+}
+
+export function normalizeOptions(
+  tree: Tree,
+  options: NxRemixGeneratorSchema
+): RemixLibraryOptions {
+  const name = names(options.name).fileName;
+
+  const { projectDirectory } = extractLayoutDirectory(options.directory);
+  const fullProjectDirectory = normalizeDirectory(name, projectDirectory);
+  const { npmScope } = getWorkspaceLayout(tree);
+
+  const importPath =
+    options.importPath ?? getImportPath(npmScope, fullProjectDirectory);
+
+  const projectName = normalizeProjectName(name, projectDirectory);
+
+  return {
+    ...options,
+    name,
+    importPath,
+    projectName,
+  };
+}

--- a/packages/remix/src/generators/library/lib/update-buildable-config.ts
+++ b/packages/remix/src/generators/library/lib/update-buildable-config.ts
@@ -1,0 +1,25 @@
+import type { Tree } from '@nx/devkit';
+import {
+  joinPathFragments,
+  readProjectConfiguration,
+  updateJson,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+export function updateBuildableConfig(tree: Tree, name: string) {
+  // Nest dist under project root to we can link it
+  const project = readProjectConfiguration(tree, name);
+  project.targets.build.options = {
+    ...project.targets.build.options,
+    format: ['cjs'],
+    outputPath: joinPathFragments(project.root, 'dist'),
+  };
+  updateProjectConfiguration(tree, name, project);
+
+  // Point to nested dist for yarn/npm/pnpm workspaces
+  updateJson(tree, joinPathFragments(project.root, 'package.json'), (json) => {
+    json.main = './dist/index.cjs.js';
+    json.typings = './dist/index.d.ts';
+    return json;
+  });
+}

--- a/packages/remix/src/generators/library/library.impl.spec.ts
+++ b/packages/remix/src/generators/library/library.impl.spec.ts
@@ -1,0 +1,58 @@
+import { readJson, readProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import libraryGenerator from './library.impl';
+
+describe('Remix Library Generator', () => {
+  it('should generate a library correctly', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+    // ACT
+    await libraryGenerator(tree, {
+      name: 'test',
+      style: 'css',
+    });
+
+    // ASSERT
+    const tsconfig = readJson(tree, 'tsconfig.base.json');
+    expect(tree.exists('libs/test/src/server.ts'));
+    expect(tree.children('libs/test/src/lib')).toMatchInlineSnapshot(`
+      Array [
+        "test.module.css",
+        "test.spec.tsx",
+        "test.tsx",
+      ]
+    `);
+    expect(tsconfig.compilerOptions.paths).toMatchInlineSnapshot(`
+      Object {
+        "@proj/test": Array [
+          "libs/test/src/index.ts",
+        ],
+        "@proj/test/server": Array [
+          "libs/test/src/server.ts",
+        ],
+      }
+    `);
+  });
+
+  // TODO(Colum): Unskip this when buildable is investigated correctly
+  xit('should generate the config files correctly when the library is buildable', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+    // ACT
+    await libraryGenerator(tree, {
+      name: 'test',
+      style: 'css',
+      buildable: true,
+    });
+
+    // ASSERT
+    const project = readProjectConfiguration(tree, 'test');
+    const pkgJson = readJson(tree, 'libs/test/package.json');
+    expect(project.targets.build.options.format).toEqual(['cjs']);
+    expect(project.targets.build.options.outputPath).toEqual('libs/test/dist');
+    expect(pkgJson.main).toEqual('./dist/index.cjs.js');
+    expect(pkgJson.typings).toEqual('./dist/index.d.ts');
+  });
+});

--- a/packages/remix/src/generators/library/schema.d.ts
+++ b/packages/remix/src/generators/library/schema.d.ts
@@ -2,8 +2,11 @@ import { SupportedStyles } from '@nx/react';
 
 export interface NxRemixGeneratorSchema {
   name: string;
+  style: SupportedStyles;
+  directory?: string;
   tags?: string;
   importPath?: string;
+  buildable?: boolean;
   js?: boolean;
-  style: SupportedStyles;
+  skipFormat?: boolean;
 }

--- a/packages/remix/src/generators/library/schema.json
+++ b/packages/remix/src/generators/library/schema.json
@@ -20,6 +20,12 @@
       "x-prompt": "What name would you like to use for the library?",
       "pattern": "^[a-zA-Z].*$"
     },
+    "directory": {
+      "type": "string",
+      "description": "A directory where the lib is placed.",
+      "alias": "dir",
+      "x-priority": "important"
+    },
     "tags": {
       "type": "string",
       "description": "Add tags to the library (used for linting)"
@@ -27,8 +33,16 @@
     "style": {
       "type": "string",
       "description": "Generate a stylesheet",
-      "enum": ["none", "css"],
+      "enum": [
+        "none",
+        "css"
+      ],
       "default": "css"
+    },
+    "buildable": {
+      "type": "boolean",
+      "description": "Should the library be buildable?",
+      "default": false
     },
     "importPath": {
       "type": "string",
@@ -38,7 +52,15 @@
       "type": "boolean",
       "description": "Generate JavaScript files rather than TypeScript files",
       "default": false
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files after generator runs",
+      "default": false,
+      "x-priority": "internal"
     }
   },
-  "required": ["name"]
+  "required": [
+    "name"
+  ]
 }

--- a/packages/remix/src/utils/project.ts
+++ b/packages/remix/src/utils/project.ts
@@ -1,0 +1,17 @@
+import { names } from '@nx/devkit';
+
+export function normalizeDirectory(
+  appName: string,
+  directoryName: string
+): string {
+  return directoryName
+    ? `${names(directoryName).fileName}/${names(appName).fileName}`
+    : names(appName).fileName;
+}
+
+export function normalizeProjectName(
+  appName: string,
+  directoryName: string
+): string {
+  return normalizeDirectory(appName, directoryName).replace(/\//g, '-');
+}


### PR DESCRIPTION
Remix Libraries should be generated with a server entrypoint in the TSConfig.


This PR does a few things:

1. Fixes generation in general -> We assumed buildable library by default and therefore tried to update the build target in the project.json -> this may not exist
2. Places buildable config updates behind a buildable flag -> this is not complete, we need to investigate buildable option further
3. The example in the schema.json shows using a directory option that does not exist -> add the directory option
4. Adds the `server.ts` file as the entrypoint for the server-only exports -> adds it to a new path in the root tsconfig file
5. Adds a `.spec.ts` file for the Library Generator -> testing isn't verbose yet, but it at least provides some confidence -> That said, we don't do anything drastic in this generator, and offload a lot of the work to the React generator which is thoroughly tested, so it could be the tests for this generator remain minor

What is still left to do regarding the server entrypoint

1. Ensuring that both these entrypoints are accessible when the library is buildable

NOTE: This means we should look into the buildable path for the library generator 
