### PR TITLE
fix(netlify): remove dependency on app lint target from functions target

### DIFF
--- a/packages/netlify/src/generators/serverless/severless.spec.ts
+++ b/packages/netlify/src/generators/serverless/severless.spec.ts
@@ -20,7 +20,6 @@ describe('serverless', () => {
         command: 'npx netlify dev',
       },
       'deploy-functions': {
-        dependsOn: ['lint'],
         command: 'npx netlify deploy',
       },
     });

--- a/packages/netlify/src/generators/setup-functions/setup-functions.spec.ts
+++ b/packages/netlify/src/generators/setup-functions/setup-functions.spec.ts
@@ -26,7 +26,6 @@ describe('setupFunctionsGenerator', () => {
           command: 'npx netlify dev',
         },
         'deploy-functions': {
-          dependsOn: ['lint'],
           command: 'npx netlify deploy',
           options: {
             cwd: 'api',
@@ -62,7 +61,6 @@ describe('setupFunctionsGenerator', () => {
           command: 'npx netlify dev',
         },
         'deploy-functions': {
-          dependsOn: ['lint'],
           command: 'npx netlify deploy',
           configurations: {
             production: {

--- a/packages/netlify/src/generators/setup-functions/setup-functions.ts
+++ b/packages/netlify/src/generators/setup-functions/setup-functions.ts
@@ -58,7 +58,6 @@ async function addTargets(tree: Tree, options: SetupFunctionsSchema) {
     };
 
     projectConfig.targets[`${options.deployTarget}`] = {
-      dependsOn: projectConfig.targets?.['lint'] ? ['lint'] : [],
       command: options.site
         ? `npx netlify deploy --site ${options.site}`
         : 'npx netlify deploy',


### PR DESCRIPTION
The `dependsOn` for the `deploy-functions` points to the lint target of the Node application, which doesn't make a whole lot of sense right now. So let's remove it

**UPDATE:** to be discussed whether we want to remove it or add the `./functions/**/*.ts` folder as well