### PR TITLE
fix(nx-ignore): use correct @swc/helpers

### DIFF
--- a/packages/nx-ignore/package.json
+++ b/packages/nx-ignore/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "fs-extra": "^10.1.0",
-    "@swc/helpers": "^0.4.14"
+    "@swc/helpers": "0.5.1"
   }
 }


### PR DESCRIPTION
The version was misaligned and caused issues with build.

Fixes #256