### PR TITLE
feat(remix): move targets to project.json

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -52,7 +52,9 @@ describe('remix e2e', () => {
   }, 120000);
 
   describe('--directory', () => {
-    it('should create src in the specified directory', async () => {
+    // TODO(Coly010) - Application does not have a directory option
+    // This test should have been failing, but it is not actually testing that the code is created in a specific directory
+    xit('should create src in the specified directory', async () => {
       const plugin = uniq('remix');
       await runNxCommandAsync(
         `generate @nx/remix:app ${plugin} --directory subdir`

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Remix Application Integrated Repo should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: ['../../libs'],
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo should create the application correctly 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Standalone Project Repo should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: ['./libs'],
+};
+"
+`;
+
+exports[`Remix Application Standalone Project Repo should create the application correctly 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Standalone Project Repo should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -1,0 +1,70 @@
+import { readJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import applicationGenerator from './application.impl';
+
+describe('Remix Application', () => {
+  describe('Standalone Project Repo', () => {
+    it('should create the application correctly', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+
+      // ACT
+      await applicationGenerator(tree, {
+        name: 'test',
+        rootProject: true,
+      });
+
+      // ASSERT
+      const { targets } = readJson(tree, 'project.json');
+      expect(targets.build).toBeTruthy();
+      expect(targets.build.command).toEqual('remix build');
+      expect(targets.build.options.cwd).toEqual('.');
+      expect(targets.serve).toBeTruthy();
+      expect(targets.serve.command).toEqual('remix dev');
+      expect(targets.serve.options.cwd).toEqual('.');
+      expect(targets.start).toBeTruthy();
+      expect(targets.start.command).toEqual('remix-serve build');
+      expect(targets.start.options.cwd).toEqual('.');
+      expect(targets.typecheck).toBeTruthy();
+      expect(targets.typecheck.command).toEqual('tsc');
+      expect(targets.typecheck.options.cwd).toEqual('.');
+
+      expect(tree.read('remix.config.js', 'utf-8')).toMatchSnapshot();
+      expect(tree.read('app/root.tsx', 'utf-8')).toMatchSnapshot();
+      expect(tree.read('app/routes/index.tsx', 'utf-8')).toMatchSnapshot();
+    });
+  });
+
+  describe('Integrated Repo', () => {
+    it('should create the application correctly', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+      // ACT
+      await applicationGenerator(tree, {
+        name: 'test',
+      });
+
+      // ASSERT
+      const { targets } = readJson(tree, 'apps/test/project.json');
+      expect(targets.build).toBeTruthy();
+      expect(targets.build.command).toEqual('remix build');
+      expect(targets.build.options.cwd).toEqual('apps/test');
+      expect(targets.serve).toBeTruthy();
+      expect(targets.serve.command).toEqual('remix dev');
+      expect(targets.serve.options.cwd).toEqual('apps/test');
+      expect(targets.start).toBeTruthy();
+      expect(targets.start.command).toEqual('remix-serve build');
+      expect(targets.start.options.cwd).toEqual('apps/test');
+      expect(targets.typecheck).toBeTruthy();
+      expect(targets.typecheck.command).toEqual('tsc');
+      expect(targets.typecheck.options.cwd).toEqual('apps/test');
+
+      expect(tree.read('apps/test/remix.config.js', 'utf-8')).toMatchSnapshot();
+      expect(tree.read('apps/test/app/root.tsx', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('apps/test/app/routes/index.tsx', 'utf-8')
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -34,6 +34,33 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
     sourceRoot: `${options.projectRoot}`,
     projectType: 'application',
     tags: options.parsedTags,
+    targets: {
+      build: {
+        command: `remix build`,
+        options: {
+          cwd: options.projectRoot,
+        },
+      },
+      serve: {
+        command: `remix dev`,
+        options: {
+          cwd: options.projectRoot,
+        },
+      },
+      start: {
+        dependsOn: ['build'],
+        command: `remix-serve build`,
+        options: {
+          cwd: options.projectRoot,
+        },
+      },
+      typecheck: {
+        command: `tsc`,
+        options: {
+          cwd: options.projectRoot,
+        },
+      },
+    },
   });
 
   const installTask = addDependenciesToPackageJson(
@@ -79,16 +106,6 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
   );
 
   if (options.rootProject) {
-    updateJson(tree, 'package.json', (json) => {
-      json['scripts'] = {
-        build: 'nx exec -- remix build',
-        dev: 'nx exec -- remix dev',
-        start: 'nx exec -- remix-serve build',
-        typecheck: 'nx exec -- tsc',
-      };
-
-      return json;
-    });
     const gitignore = tree.read('.gitignore', 'utf-8');
     tree.write(
       '.gitignore',

--- a/packages/remix/src/generators/application/files/integrated/package.json__tmpl__
+++ b/packages/remix/src/generators/application/files/integrated/package.json__tmpl__
@@ -3,12 +3,7 @@
   "name": "<%= projectName %>",
   "description": "",
   "license": "",
-  "scripts": {
-    "build": "nx exec -- remix build",
-    "dev": "nx exec -- remix dev",
-    "start": "nx exec -- remix-serve build",
-    "typecheck": "nx exec -- tsc"
-  },
+  "scripts": {},
   "dependencies": {
     "@remix-run/node": "<%= remixVersion %>",
     "@remix-run/react": "<%= remixVersion %>",


### PR DESCRIPTION
Remix applications are currently running via scripts in package.json

Move these scripts to run-commands in project.json

Add some unit tests to the application generator to ensure it is being created as expected
