### PR TITLE
chore(remix): improve route test to confirm output is expected

### DIFF
--- a/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
+++ b/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`route should add route component 1`] = `
+"import type {
+  ActionArgs,
+  LinksFunction,
+  LoaderArgs,
+  MetaFunction,
+} from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useActionData, useLoaderData } from '@remix-run/react';
+
+import stylesUrl from '../../../styles/path/to/example.css';
+
+export const links: LinksFunction = () => {
+  return [{ rel: 'stylesheet', href: stylesUrl }];
+};
+
+export const action = async ({ request }: ActionArgs) => {
+  let formData = await request.formData();
+
+  return json({ message: formData.toString() }, { status: 200 });
+};
+
+export const meta: MetaFunction = () => {
+  return { title: 'PathToExample Route' };
+};
+
+export const loader = async ({ request }: LoaderArgs) => {
+  return json({
+    message: 'Hello, world!',
+  });
+};
+
+export default function PathToExample() {
+  const actionMessage = useActionData<typeof action>();
+  const data = useLoaderData<typeof loader>();
+
+  return <p>Message: {data.message}</p>;
+}
+"
+`;

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -3,6 +3,7 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import presetGenerator from '../preset/preset.impl';
 import routeGenerator from './route.impl';
+
 describe('route', () => {
   let tree: Tree;
 
@@ -23,9 +24,11 @@ describe('route', () => {
       skipChecks: false,
     });
 
-    const content = tree
-      .read('apps/demo/app/routes/path/to/example.tsx')
-      .toString();
+    const content = tree.read(
+      'apps/demo/app/routes/path/to/example.tsx',
+      'utf-8'
+    );
+    expect(content).toMatchSnapshot();
     expect(content).toMatch('LinksFunction');
     expect(content).toMatch('function PathToExample(');
     expect(


### PR DESCRIPTION
The test we have for route currently just checks that some text appears in the route file.

I've added a snapshot test to improve the accuracy of what gets generated and to fail quicker if a change is made.
Right now, we generate a meta, action and loader along with the route component. 

This is confirmed by the snapshot. This may become more important when we upgrade to v2
