### PR TITLE
feat(remix): add --directory option to application

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -52,14 +52,16 @@ describe('remix e2e', () => {
   }, 120000);
 
   describe('--directory', () => {
-    // TODO(Coly010) - Application does not have a directory option
-    // This test should have been failing, but it is not actually testing that the code is created in a specific directory
-    xit('should create src in the specified directory', async () => {
+    it('should create src in the specified directory', async () => {
       const plugin = uniq('remix');
+      const appName = `subdir-${plugin}`;
       await runNxCommandAsync(
-        `generate @nx/remix:app ${plugin} --directory subdir`
+        `generate @nx/remix:app ${plugin} --directory subdir --rootProject=false`
       );
-      const result = await runNxCommandAsync(`build ${plugin}`);
+      const project = readJson(`subdir/${plugin}/project.json`);
+      expect(project.targets.build.options.cwd).toEqual(`subdir/${plugin}`);
+
+      const result = await runNxCommandAsync(`build ${appName}`);
       expect(result.stdout).toContain('Successfully ran target build');
     }, 120000);
   });

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -1,5 +1,179 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Remix Application Integrated Repo --directory should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: ['../../../libs'],
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --directory should create the application correctly 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --directory should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --directory should extract the layout directory from the directory options if it exists 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: ['../../../libs'],
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --directory should extract the layout directory from the directory options if it exists 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --directory should extract the layout directory from the directory options if it exists 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
 exports[`Remix Application Integrated Repo should create the application correctly 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -66,5 +66,71 @@ describe('Remix Application', () => {
         tree.read('apps/test/app/routes/index.tsx', 'utf-8')
       ).toMatchSnapshot();
     });
+
+    describe('--directory', () => {
+      it('should create the application correctly', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+        // ACT
+        await applicationGenerator(tree, {
+          name: 'test',
+          directory: 'demo',
+        });
+
+        // ASSERT
+        const { targets } = readJson(tree, 'apps/demo/test/project.json');
+        expect(targets.build).toBeTruthy();
+        expect(targets.build.command).toEqual('remix build');
+        expect(targets.build.options.cwd).toEqual('apps/demo/test');
+        expect(targets.serve).toBeTruthy();
+        expect(targets.serve.command).toEqual('remix dev');
+        expect(targets.serve.options.cwd).toEqual('apps/demo/test');
+        expect(targets.start).toBeTruthy();
+        expect(targets.start.command).toEqual('remix-serve build');
+        expect(targets.start.options.cwd).toEqual('apps/demo/test');
+        expect(targets.typecheck).toBeTruthy();
+        expect(targets.typecheck.command).toEqual('tsc');
+        expect(targets.typecheck.options.cwd).toEqual('apps/demo/test');
+
+        expect(
+          tree.read('apps/demo/test/remix.config.js', 'utf-8')
+        ).toMatchSnapshot();
+        expect(
+          tree.read('apps/demo/test/app/root.tsx', 'utf-8')
+        ).toMatchSnapshot();
+        expect(
+          tree.read('apps/demo/test/app/routes/index.tsx', 'utf-8')
+        ).toMatchSnapshot();
+      });
+
+      it('should extract the layout directory from the directory options if it exists', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+        // ACT
+        await applicationGenerator(tree, {
+          name: 'test',
+          directory: 'apps/demo',
+        });
+
+        // ASSERT
+        const { targets } = readJson(tree, 'apps/demo/test/project.json');
+        expect(targets.build).toBeTruthy();
+        expect(targets.serve).toBeTruthy();
+        expect(targets.start).toBeTruthy();
+        expect(targets.typecheck).toBeTruthy();
+
+        expect(
+          tree.read('apps/demo/test/remix.config.js', 'utf-8')
+        ).toMatchSnapshot();
+        expect(
+          tree.read('apps/demo/test/app/root.tsx', 'utf-8')
+        ).toMatchSnapshot();
+        expect(
+          tree.read('apps/demo/test/app/routes/index.tsx', 'utf-8')
+        ).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/packages/remix/src/generators/application/lib/normalize-options.ts
+++ b/packages/remix/src/generators/application/lib/normalize-options.ts
@@ -1,4 +1,13 @@
-import { getWorkspaceLayout, joinPathFragments, names, Tree } from '@nx/devkit';
+import {
+  extractLayoutDirectory,
+  getWorkspaceLayout,
+  joinPathFragments,
+  Tree,
+} from '@nx/devkit';
+import {
+  normalizeDirectory,
+  normalizeProjectName,
+} from '../../../utils/project';
 import { NxRemixGeneratorSchema } from '../schema';
 
 export interface NormalizedSchema extends NxRemixGeneratorSchema {
@@ -11,12 +20,17 @@ export function normalizeOptions(
   tree: Tree,
   options: NxRemixGeneratorSchema
 ): NormalizedSchema {
-  const { appsDir } = getWorkspaceLayout(tree);
-  const name = names(options.name).fileName;
-  const projectName = name;
+  const { layoutDirectory, projectDirectory } = extractLayoutDirectory(
+    options.directory
+  );
+  const appDirectory = normalizeDirectory(options.name, projectDirectory);
+  const appName = normalizeProjectName(options.name, projectDirectory);
+  const { appsDir: defaultAppsDir } = getWorkspaceLayout(tree);
+  const appsDir = layoutDirectory ?? defaultAppsDir;
+  const projectName = appName;
   const projectRoot = options.rootProject
     ? '.'
-    : joinPathFragments(appsDir, name);
+    : joinPathFragments(appsDir, appDirectory);
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -1,6 +1,7 @@
 export interface NxRemixGeneratorSchema {
   name: string;
   tags?: string;
+  directory?: string;
   skipFormat?: boolean;
   rootProject?: boolean;
 }

--- a/packages/remix/src/generators/application/schema.json
+++ b/packages/remix/src/generators/application/schema.json
@@ -13,6 +13,12 @@
       },
       "x-prompt": "What is the name of the application?"
     },
+    "directory": {
+      "type": "string",
+      "description": "A directory where the app is placed.",
+      "alias": "dir",
+      "x-priority": "important"
+    },
     "tags": {
       "type": "string",
       "description": "Add tags to the project (used for linting)",


### PR DESCRIPTION
We currently do not offer a `--directory` option when generating a remix application.

Offer a `--directory` option when generating a remix application.
