### PR TITLE
feat(remix): add --js option to application

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -77,6 +77,16 @@ describe('remix e2e', () => {
     }, 120000);
   });
 
+  describe('--js', () => {
+    it('should create js app and build correctly', async () => {
+      const plugin = uniq('remix');
+      await runNxCommandAsync(`generate @nx/remix:app ${plugin} --js=true`);
+
+      const result = await runNxCommandAsync(`build ${plugin}`);
+      expect(result.stdout).toContain('Successfully ran target build');
+    }, 120000);
+  });
+
   describe('error checking', () => {
     const plugin = uniq('remix');
 

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -1,5 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Remix Application Integrated Repo --js should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: ['../../libs'],
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --js should create the application correctly 2`] = `
+"import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+export const meta = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --js should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
 exports[`Remix Application Integrated Repo --directory should create the application correctly 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
@@ -226,6 +310,90 @@ export default function App() {
 `;
 
 exports[`Remix Application Integrated Repo should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Standalone Project Repo --js should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: ['./libs'],
+};
+"
+`;
+
+exports[`Remix Application Standalone Project Repo --js should create the application correctly 2`] = `
+"import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+export const meta = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Standalone Project Repo --js should create the application correctly 3`] = `
 "export default function Index() {
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -8,6 +8,7 @@ import {
   offsetFromRoot,
   readJson,
   runTasksInSerial,
+  toJS,
   Tree,
   updateJson,
 } from '@nx/devkit';
@@ -22,7 +23,7 @@ import {
   typesReactDomVersion,
   typesReactVersion,
 } from '../../utils/versions';
-import { normalizeOptions } from './lib/normalize-options';
+import { normalizeOptions } from './lib';
 import { NxRemixGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
@@ -118,6 +119,10 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
       options.projectRoot,
       vars
     );
+  }
+
+  if (options.js) {
+    toJS(tree);
   }
 
   if (options.rootProject && tree.exists('tsconfig.base.json')) {

--- a/packages/remix/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/remix/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -1,6 +1,6 @@
 {
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
-  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2019"],
     "isolatedModules": true,

--- a/packages/remix/src/generators/application/lib/index.ts
+++ b/packages/remix/src/generators/application/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './normalize-options';

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -1,6 +1,7 @@
 export interface NxRemixGeneratorSchema {
   name: string;
   tags?: string;
+  js?: boolean;
   directory?: string;
   skipFormat?: boolean;
   rootProject?: boolean;

--- a/packages/remix/src/generators/application/schema.json
+++ b/packages/remix/src/generators/application/schema.json
@@ -13,6 +13,11 @@
       },
       "x-prompt": "What is the name of the application?"
     },
+    "js": {
+      "type": "boolean",
+      "description": "Generate JavaScript files rather than TypeScript files.",
+      "default": false
+    },
     "directory": {
       "type": "string",
       "description": "A directory where the app is placed.",


### PR DESCRIPTION
We do not currently offer a `--js` option for users to use JS instead of TS when generating applications

We should offer `--js` option
