### PR TITLE
feat(remix): add util to create watchPaths configuration option automatically

### DIFF
--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -10,7 +10,7 @@ module.exports = {
   // assetsBuildDirectory: \\"public/build\\",
   // serverBuildPath: \\"build/index.js\\",
   // publicPath: \\"/build/\\",
-  watchPaths: ['../../libs'],
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
 };
 "
 `;
@@ -97,7 +97,7 @@ module.exports = {
   // assetsBuildDirectory: \\"public/build\\",
   // serverBuildPath: \\"build/index.js\\",
   // publicPath: \\"/build/\\",
-  watchPaths: ['./libs'],
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
 };
 "
 `;

--- a/packages/remix/src/generators/application/files/common/remix.config.js__tmpl__
+++ b/packages/remix/src/generators/application/files/common/remix.config.js__tmpl__
@@ -7,5 +7,5 @@ module.exports = {
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   // publicPath: "/build/",
-  watchPaths: ["<%= offsetFromRoot %>libs"]
+  watchPaths: () => require("@nx/remix").createWatchPaths(__dirname),
 };

--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -8,3 +8,4 @@ export * from './generators/preset/preset.impl';
 export * from './generators/resource-route/resource-route.impl';
 export * from './generators/route/route.impl';
 export * from './generators/style/style.impl';
+export { createWatchPaths } from './utils/create-watch-paths';

--- a/packages/remix/src/utils/create-watch-paths.spec.ts
+++ b/packages/remix/src/utils/create-watch-paths.spec.ts
@@ -1,0 +1,160 @@
+import { joinPathFragments, workspaceRoot } from '@nx/devkit';
+import {
+  createWatchPaths,
+  getRelativeDependencyPaths,
+} from './create-watch-paths';
+
+describe('createWatchPaths', () => {
+  it('should list root paths of dependencies relative to project root', async () => {
+    const testDir = joinPathFragments(workspaceRoot, 'e2e/remix-e2e');
+
+    const paths = await createWatchPaths(testDir);
+    expect(paths).toEqual(['../../packages']);
+  });
+});
+
+describe('getRelativeDependencyPaths', () => {
+  it('should work for standalone projects', () => {
+    const project = {
+      type: 'app' as const,
+      name: 'test',
+      data: { root: '.', files: [] },
+    };
+    const result = getRelativeDependencyPaths(
+      project,
+      ['lib-1', 'lib-2', 'lib-3'],
+      {
+        nodes: {
+          test: project,
+          'lib-1': {
+            type: 'lib',
+            name: 'lib-1',
+            data: { root: 'lib-1', files: [] },
+          },
+          'lib-2': {
+            type: 'lib',
+            name: 'lib-2',
+            data: { root: 'lib-2', files: [] },
+          },
+          'lib-3': {
+            type: 'lib',
+            name: 'lib-3',
+            data: { root: 'lib-3', files: [] },
+          },
+        },
+        dependencies: {},
+      }
+    );
+
+    expect(result).toEqual(['lib-1', 'lib-2', 'lib-3']);
+  });
+
+  it('should watch the entire libs folder for integrated monorepos', () => {
+    const project = {
+      type: 'app' as const,
+      name: 'test',
+      data: { root: 'apps/test', files: [] },
+    };
+    const result = getRelativeDependencyPaths(
+      project,
+      ['lib-1', 'lib-2', 'lib-3'],
+      {
+        nodes: {
+          test: project,
+          'lib-1': {
+            type: 'lib',
+            name: 'lib-1',
+            data: { root: 'libs/lib-1', files: [] },
+          },
+          'lib-2': {
+            type: 'lib',
+            name: 'lib-2',
+            data: { root: 'libs/lib-2', files: [] },
+          },
+          'lib-3': {
+            type: 'lib',
+            name: 'lib-3',
+            data: { root: 'libs/lib-3', files: [] },
+          },
+        },
+        dependencies: {},
+      }
+    );
+
+    expect(result).toEqual(['../../libs']);
+  });
+
+  it('should watch the entire packages folder for monorepos if apps is not contained in it', () => {
+    const project = {
+      type: 'app' as const,
+      name: 'test',
+      data: { root: 'apps/test', files: [] },
+    };
+    const result = getRelativeDependencyPaths(
+      project,
+      ['lib-1', 'lib-2', 'lib-3'],
+      {
+        nodes: {
+          test: project,
+          'lib-1': {
+            type: 'lib',
+            name: 'lib-1',
+            data: { root: 'packages/lib-1', files: [] },
+          },
+          'lib-2': {
+            type: 'lib',
+            name: 'lib-2',
+            data: { root: 'packages/lib-2', files: [] },
+          },
+          'lib-3': {
+            type: 'lib',
+            name: 'lib-3',
+            data: { root: 'packages/lib-3', files: [] },
+          },
+        },
+        dependencies: {},
+      }
+    );
+
+    expect(result).toEqual(['../../packages']);
+  });
+
+  it('should watch individual dependency folder if app is contained in the same base path', () => {
+    const project = {
+      type: 'app' as const,
+      name: 'test',
+      data: { root: 'packages/test', files: [] },
+    };
+    const result = getRelativeDependencyPaths(
+      project,
+      ['lib-1', 'lib-2', 'lib-3'],
+      {
+        nodes: {
+          test: project,
+          'lib-1': {
+            type: 'lib',
+            name: 'lib-1',
+            data: { root: 'packages/lib-1', files: [] },
+          },
+          'lib-2': {
+            type: 'lib',
+            name: 'lib-2',
+            data: { root: 'packages/lib-2', files: [] },
+          },
+          'lib-3': {
+            type: 'lib',
+            name: 'lib-3',
+            data: { root: 'packages/lib-3', files: [] },
+          },
+        },
+        dependencies: {},
+      }
+    );
+
+    expect(result).toEqual([
+      '../../packages/lib-1',
+      '../../packages/lib-2',
+      '../../packages/lib-3',
+    ]);
+  });
+});

--- a/packages/remix/src/utils/create-watch-paths.ts
+++ b/packages/remix/src/utils/create-watch-paths.ts
@@ -1,0 +1,59 @@
+import {
+  createProjectGraphAsync,
+  joinPathFragments,
+  offsetFromRoot,
+  workspaceRoot,
+  type ProjectGraph,
+  type ProjectGraphProjectNode,
+} from '@nx/devkit';
+import {
+  createProjectRootMappings,
+  findProjectForPath,
+} from 'nx/src/project-graph/utils/find-project-for-path';
+import { findAllProjectNodeDependencies } from 'nx/src/utils/project-graph-utils';
+import { normalize, relative, sep } from 'path';
+
+/**
+ * Generates an array of paths to watch based on the project dependencies.
+ *
+ * @param {string} dirname The absolute path to the Remix project, typically `__dirname`.
+ */
+export async function createWatchPaths(dirname: string): Promise<string[]> {
+  const graph = await createProjectGraphAsync();
+  const projectRootMappings = createProjectRootMappings(graph.nodes);
+  const projectName = findProjectForPath(
+    relative(workspaceRoot, dirname),
+    projectRootMappings
+  );
+  const deps = findAllProjectNodeDependencies(projectName, graph);
+
+  return getRelativeDependencyPaths(graph.nodes[projectName], deps, graph);
+}
+
+// Exported for testing
+export function getRelativeDependencyPaths(
+  project: ProjectGraphProjectNode,
+  deps: string[],
+  graph: ProjectGraph
+): string[] {
+  if (!project.data?.root) {
+    throw new Error(
+      `Project ${project.name} has no root set. Check the project configuration.`
+    );
+  }
+
+  const paths = new Set<string>();
+  const offset = offsetFromRoot(project.data.root);
+  const [baseProjectPath] = project.data.root.split('/');
+
+  for (const dep of deps) {
+    const node = graph.nodes[dep];
+    if (!node?.data?.root) continue;
+    const [basePath] = normalize(node.data.root).split(sep);
+    const watchPath = baseProjectPath !== basePath ? basePath : node.data.root;
+    const relativeWatchPath = joinPathFragments(offset, watchPath);
+    paths.add(relativeWatchPath);
+  }
+
+  return Array.from(paths);
+}


### PR DESCRIPTION
This PR adds a `createWatchPaths` util function in `@nx/remix` that returns libs and packages paths relative to the app root. e.g. `['../../lib', '../../packages']`

We could narrow it down to only the libraries used by the app, but that optimization doesn't seem necessary as demonstrated here by a project with 1K libs and other 100K files under `libs`: https://github.com/jaysoo/nx-remix-large-repo. Each subsequent update takes less than a second to refresh. If we narrow down to specific lib folders, then the app will need to be restarted whenever the dep graph changes, which is not great DX.