### PR TITLE
feat(remix): add error boundary generator

### DIFF
--- a/packages/remix/generators.json
+++ b/packages/remix/generators.json
@@ -60,6 +60,11 @@
       "schema": "./src/generators/meta/schema.json",
       "description": "Add a meta function to an existing route"
     },
+    "error-boundary": {
+      "implementation": "./src/generators/error-boundary/error-boundary.impl",
+      "schema": "./src/generators/error-boundary/schema.json",
+      "description": "Add an ErrorBoundary to an existing route"
+    },
     "cypress": {
       "implementation": "./src/generators/cypress/cypress.impl",
       "schema": "./src/generators/cypress/schema.json",

--- a/packages/remix/src/generators/error-boundary/__snapshots__/error-boundary.impl.spec.ts.snap
+++ b/packages/remix/src/generators/error-boundary/__snapshots__/error-boundary.impl.spec.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorBoundary --apiVersion=1 should correctly add the ErrorBoundary to the route file 1`] = `
+"export function ErrorBoundary({ error }) {
+  console.error(error);
+  return (
+    <div>
+      <h1>Uh oh ...</h1>
+      <p>Something went wrong</p>
+      <pre>{error.message || 'Unknown error'}</pre>
+    </div>
+  );
+}
+"
+`;
+
+exports[`ErrorBoundary --apiVersion=2 should correctly add the ErrorBoundary to the route file 1`] = `
+"import { isRouteErrorResponse, useRouteError } from '@remix-run/react';
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  // when true, this is what used to go to 'CatchBoundary'
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div>
+        <h1>Oops</h1>
+        <p>Status: {error.status}</p>
+        <p>{error.data.message}</p>
+      </div>
+    );
+  }
+
+  // Don't forget to typecheck with your own logic.
+  // Any value can be thrown, not just errors!
+  let errorMessage = 'Unknown error';
+  // if (isDefinitelyAnError(error)) {
+  //    errorMessage = error.message;
+  // }
+
+  return (
+    <div>
+      <h1>Uh oh ...</h1>
+      <p>Something went wrong.</p>
+      <pre>{errorMessage}</pre>
+    </div>
+  );
+}
+"
+`;

--- a/packages/remix/src/generators/error-boundary/error-boundary.impl.spec.ts
+++ b/packages/remix/src/generators/error-boundary/error-boundary.impl.spec.ts
@@ -1,0 +1,103 @@
+import { addProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import errorBoundaryGenerator from './error-boundary.impl';
+
+describe('ErrorBoundary', () => {
+  describe('--apiVersion=1', () => {
+    it('should correctly add the ErrorBoundary to the route file', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      addProjectConfiguration(tree, 'demo', {
+        name: 'demo',
+        root: '.',
+        sourceRoot: '.',
+        projectType: 'application',
+      });
+      const routeFilePath = `app/routes/test.tsx`;
+      tree.write(routeFilePath, ``);
+      tree.write('remix.config.js', `module.exports = {}`);
+
+      // ACT
+      await errorBoundaryGenerator(tree, {
+        project: 'demo',
+        path: routeFilePath,
+        apiVersion: 1,
+      });
+
+      // ASSERT
+      expect(tree.read(routeFilePath, 'utf-8')).toMatchSnapshot();
+    });
+
+    it('should error when the route file cannot be found', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      addProjectConfiguration(tree, 'demo', {
+        name: 'demo',
+        root: '.',
+        sourceRoot: '.',
+        projectType: 'application',
+      });
+      const routeFilePath = `app/routes/test.tsx`;
+      tree.write(routeFilePath, ``);
+      tree.write('remix.config.js', `module.exports = {}`);
+
+      // ACT & ASSERT
+      await expect(
+        errorBoundaryGenerator(tree, {
+          project: 'demo',
+          path: `my-route.tsx`,
+          apiVersion: 1,
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('--apiVersion=2', () => {
+    it('should correctly add the ErrorBoundary to the route file', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      addProjectConfiguration(tree, 'demo', {
+        name: 'demo',
+        root: '.',
+        sourceRoot: '.',
+        projectType: 'application',
+      });
+      const routeFilePath = `app/routes/test.tsx`;
+      tree.write(routeFilePath, ``);
+      tree.write('remix.config.js', `module.exports = {}`);
+
+      // ACT
+      await errorBoundaryGenerator(tree, {
+        project: 'demo',
+        path: routeFilePath,
+        apiVersion: 2,
+      });
+
+      // ASSERT
+      expect(tree.read(routeFilePath, 'utf-8')).toMatchSnapshot();
+    });
+
+    it('should error when the route file cannot be found', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace();
+      addProjectConfiguration(tree, 'demo', {
+        name: 'demo',
+        root: '.',
+        sourceRoot: '.',
+        projectType: 'application',
+      });
+      const routeFilePath = `app/routes/test.tsx`;
+      tree.write(routeFilePath, ``);
+      tree.write('remix.config.js', `module.exports = {}`);
+
+      // ACT & ASSERT
+      await expect(
+        errorBoundaryGenerator(tree, {
+          project: 'demo',
+          path: `my-route.tsx`,
+          apiVersion: 2,
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/remix/src/generators/error-boundary/error-boundary.impl.ts
+++ b/packages/remix/src/generators/error-boundary/error-boundary.impl.ts
@@ -1,0 +1,24 @@
+import { formatFiles, type Tree } from '@nx/devkit';
+import {
+  addV1ErrorBoundary,
+  addV2ErrorBoundary,
+  normalizeOptions,
+} from './lib';
+import type { ErrorBoundarySchema } from './schema';
+
+export default async function errorBoundaryGenerator(
+  tree: Tree,
+  schema: ErrorBoundarySchema
+) {
+  const options = normalizeOptions(tree, schema);
+
+  if (options.apiVersion === 1) {
+    addV1ErrorBoundary(tree, options);
+  } else {
+    addV2ErrorBoundary(tree, options);
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+}

--- a/packages/remix/src/generators/error-boundary/lib/add-v1-error-boundary.ts
+++ b/packages/remix/src/generators/error-boundary/lib/add-v1-error-boundary.ts
@@ -1,0 +1,22 @@
+import { stripIndents, type Tree } from '@nx/devkit';
+import { insertStatementAfterImports } from '../../../utils/insert-statement-after-imports';
+import type { ErrorBoundarySchema } from '../schema';
+
+export function addV1ErrorBoundary(tree: Tree, options: ErrorBoundarySchema) {
+  insertStatementAfterImports(
+    tree,
+    options.path,
+    stripIndents`
+    export function ErrorBoundary({ error }) {
+        console.error(error);
+        return (
+            <div>
+                <h1>Uh oh ...</h1>
+                <p>Something went wrong</p>
+                <pre>{error.message || "Unknown error"}</pre>
+            </div>
+        );
+    }
+  `
+  );
+}

--- a/packages/remix/src/generators/error-boundary/lib/add-v2-error-boundary.ts
+++ b/packages/remix/src/generators/error-boundary/lib/add-v2-error-boundary.ts
@@ -1,0 +1,45 @@
+import { stripIndents, type Tree } from '@nx/devkit';
+import { insertImport } from '../../../utils/insert-import';
+import { insertStatementAfterImports } from '../../../utils/insert-statement-after-imports';
+import type { ErrorBoundarySchema } from '../schema';
+
+export function addV2ErrorBoundary(tree: Tree, options: ErrorBoundarySchema) {
+  insertImport(tree, options.path, `useRouteError`, '@remix-run/react');
+  insertImport(tree, options.path, `isRouteErrorResponse`, '@remix-run/react');
+
+  insertStatementAfterImports(
+    tree,
+    options.path,
+    stripIndents`
+    export function ErrorBoundary() {
+        const error = useRouteError();
+
+        // when true, this is what used to go to 'CatchBoundary'
+        if (isRouteErrorResponse(error)) {
+            return (
+                <div>
+                    <h1>Oops</h1>
+                    <p>Status: {error.status}</p>
+                    <p>{error.data.message}</p>
+                </div>
+            );
+        }
+
+        // Don't forget to typecheck with your own logic.
+        // Any value can be thrown, not just errors!
+        let errorMessage = "Unknown error";
+        // if (isDefinitelyAnError(error)) {
+        //    errorMessage = error.message;
+        // }
+
+        return (
+            <div>
+                <h1>Uh oh ...</h1>
+                <p>Something went wrong.</p>
+                <pre>{errorMessage}</pre>
+            </div>
+        );
+    }
+  `
+  );
+}

--- a/packages/remix/src/generators/error-boundary/lib/index.ts
+++ b/packages/remix/src/generators/error-boundary/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './add-v1-error-boundary';
+export * from './add-v2-error-boundary';
+export * from './normalize-options';

--- a/packages/remix/src/generators/error-boundary/lib/normalize-options.ts
+++ b/packages/remix/src/generators/error-boundary/lib/normalize-options.ts
@@ -1,0 +1,25 @@
+import { type Tree } from '@nx/devkit';
+import { resolveRemixRouteFile } from '../../../utils/remix-route-utils';
+import type { ErrorBoundarySchema } from '../schema';
+
+export function normalizeOptions(
+  tree: Tree,
+  schema: ErrorBoundarySchema
+): ErrorBoundarySchema {
+  const pathToRouteFile = resolveRemixRouteFile(
+    tree,
+    schema.path,
+    schema.project
+  );
+
+  if (!tree.exists(pathToRouteFile)) {
+    throw new Error(
+      `Route file specified does not exist "${pathToRouteFile}". Please ensure you pass a correct path to the file, relative to the project root.`
+    );
+  }
+
+  return {
+    ...schema,
+    path: pathToRouteFile,
+  };
+}

--- a/packages/remix/src/generators/error-boundary/schema.d.ts
+++ b/packages/remix/src/generators/error-boundary/schema.d.ts
@@ -1,0 +1,6 @@
+export interface ErrorBoundarySchema {
+  project: string;
+  path: string;
+  apiVersion: number;
+  skipFormat?: false;
+}

--- a/packages/remix/src/generators/error-boundary/schema.json
+++ b/packages/remix/src/generators/error-boundary/schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxRemixErrorBoundary",
+  "title": "Create an ErrorBoundary for a Route",
+  "type": "object",
+  "examples": [
+    {
+      "command": "g error-boundary --project=myapp --routePath=app/routes/my-route.tsx",
+      "description": "Generate an ErrorBoundary for my-route.tsx"
+    }
+  ],
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      },
+      "x-prompt": "What project contains the route file that this ErrorBoundary is for?",
+      "pattern": "^[a-zA-Z].*$"
+    },
+    "path": {
+      "type": "string",
+      "description": "The path to route file relative to the project root."
+    },
+    "apiVersion": {
+      "type": "number",
+      "description": "Which version of the ErrorBoundary convention to use for the route.",
+      "default": 1
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files after generation.",
+      "default": false,
+      "x-priority": "internal"
+    }
+  },
+  "required": ["project", "path"]
+}


### PR DESCRIPTION
We currently do not have an ErrorBoundary generator

Add an ErrorBoundary generator

Note: We currently have a `--version` flag to switch between the two implementations of ErrorBoundary. When this is moved to the main repo and we switch to V2 only, we can remove the v1 option.

