### PR TITLE
feat(remix): allow vitest to be used for libs

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -87,6 +87,18 @@ describe('remix e2e', () => {
     }, 120000);
   });
 
+  describe('--unitTestRunner', () => {
+    it('should generate a library with vitest and test correctly', async () => {
+      const plugin = uniq('remix');
+      await runNxCommandAsync(
+        `generate @nx/remix:library ${plugin} --unitTestRunner=vitest`
+      );
+
+      const result = await runNxCommandAsync(`test ${plugin}`);
+      expect(result.stdout).toContain(`Successfully ran target test`);
+    }, 120_000);
+  });
+
   describe('error checking', () => {
     const plugin = uniq('remix');
 

--- a/packages/remix/src/generators/library/lib/add-unit-testing.ts
+++ b/packages/remix/src/generators/library/lib/add-unit-testing.ts
@@ -1,0 +1,133 @@
+import {
+  addDependenciesToPackageJson,
+  joinPathFragments,
+  readProjectConfiguration,
+  stripIndents,
+  type Tree,
+} from '@nx/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import {
+  testingLibraryJestDomVersion,
+  testingLibraryReactVersion,
+  testingLibraryUserEventsVersion,
+} from '../../../utils/versions';
+import type { RemixLibraryOptions } from './normalize-options';
+
+export function addUnitTestingSetup(tree: Tree, options: RemixLibraryOptions) {
+  const { root: projectRoot } = readProjectConfiguration(
+    tree,
+    options.projectName
+  );
+  const pathToTestSetup = joinPathFragments(projectRoot, 'src/test-setup.ts');
+  let testSetupFileContents = '';
+
+  if (tree.exists(pathToTestSetup)) {
+    testSetupFileContents = tree.read(pathToTestSetup, 'utf-8');
+  }
+
+  tree.write(
+    pathToTestSetup,
+    stripIndents`${testSetupFileContents}
+    import { installGlobals } from '@remix-run/node';
+    import "@testing-library/jest-dom/extend-expect";
+  installGlobals();`
+  );
+
+  if (options.unitTestRunner === 'vitest') {
+    const pathToVitestConfig = joinPathFragments(projectRoot, `vite.config.ts`);
+    updateViteTestSetup(tree, pathToVitestConfig);
+  } else if (options.unitTestRunner === 'jest') {
+    const pathToJestConfig = joinPathFragments(projectRoot, `jest.config.ts`);
+    updateJestTestSetup(tree, pathToJestConfig);
+  }
+
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      '@testing-library/jest-dom': testingLibraryJestDomVersion,
+      '@testing-library/react': testingLibraryReactVersion,
+      '@testing-library/user-event': testingLibraryUserEventsVersion,
+    }
+  );
+}
+
+function updateViteTestSetup(tree: Tree, pathToViteConfig: string) {
+  const fileContents = tree.read(pathToViteConfig, 'utf-8');
+
+  const ast = tsquery.ast(fileContents);
+
+  const TEST_SETUPFILES_SELECTOR =
+    'PropertyAssignment:has(Identifier[name=test]) PropertyAssignment:has(Identifier[name=setupFiles])';
+  const nodes = tsquery(ast, TEST_SETUPFILES_SELECTOR, {
+    visitAllChildren: true,
+  });
+
+  if (nodes.length === 0) {
+    const TEST_CONFIG_SELECTOR =
+      'PropertyAssignment:has(Identifier[name=test]) > ObjectLiteralExpression';
+    const testConfigNodes = tsquery(ast, TEST_CONFIG_SELECTOR, {
+      visitAllChildren: true,
+    });
+    const updatedFileContents = stripIndents`${fileContents.slice(
+      0,
+      testConfigNodes[0].getStart() + 1
+    )}setupFiles: ['./src/test-setup.ts'],${fileContents.slice(
+      testConfigNodes[0].getStart() + 1
+    )}`;
+    tree.write(pathToViteConfig, updatedFileContents);
+  } else {
+    const arrayNodes = tsquery(nodes[0], 'ArrayLiteralExpression', {
+      visitAllChildren: true,
+    });
+    if (arrayNodes.length !== 0) {
+      const updatedFileContents = stripIndents`${fileContents.slice(
+        0,
+        arrayNodes[0].getStart() + 1
+      )}'./src/test-setup.ts',${fileContents.slice(
+        arrayNodes[0].getStart() + 1
+      )}`;
+
+      tree.write(pathToViteConfig, updatedFileContents);
+    }
+  }
+}
+
+function updateJestTestSetup(tree: Tree, pathToJestConfig: string) {
+  const fileContents = tree.read(pathToJestConfig, 'utf-8');
+
+  const ast = tsquery.ast(fileContents);
+
+  const TEST_SETUPFILES_SELECTOR =
+    'PropertyAssignment:has(Identifier[name=setupFilesAfterEnv])';
+  const nodes = tsquery(ast, TEST_SETUPFILES_SELECTOR, {
+    visitAllChildren: true,
+  });
+
+  if (nodes.length === 0) {
+    const CONFIG_SELECTOR = 'ObjectLiteralExpression';
+    const nodes = tsquery(ast, CONFIG_SELECTOR, { visitAllChildren: true });
+
+    const updatedFileContents = stripIndents`${fileContents.slice(
+      0,
+      nodes[0].getStart() + 1
+    )}setupFilesAfterEnv: ['./src/test-setup.ts'],${fileContents.slice(
+      nodes[0].getStart() + 1
+    )}`;
+    tree.write(pathToJestConfig, updatedFileContents);
+  } else {
+    const arrayNodes = tsquery(nodes[0], 'ArrayLiteralExpression', {
+      visitAllChildren: true,
+    });
+    if (arrayNodes.length !== 0) {
+      const updatedFileContents = stripIndents`${fileContents.slice(
+        0,
+        arrayNodes[0].getStart() + 1
+      )}'./src/test-setup.ts',${fileContents.slice(
+        arrayNodes[0].getStart() + 1
+      )}`;
+
+      tree.write(pathToJestConfig, updatedFileContents);
+    }
+  }
+}

--- a/packages/remix/src/generators/library/lib/index.ts
+++ b/packages/remix/src/generators/library/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './add-tsconfig-entry-points';
+export * from './add-unit-testing';
 export * from './normalize-options';
 export * from './update-buildable-config';

--- a/packages/remix/src/generators/library/lib/normalize-options.ts
+++ b/packages/remix/src/generators/library/lib/normalize-options.ts
@@ -28,6 +28,7 @@ export function normalizeOptions(
 
   return {
     ...options,
+    unitTestRunner: options.unitTestRunner ?? 'vitest',
     name,
     importPath,
     projectName,

--- a/packages/remix/src/generators/library/library.impl.spec.ts
+++ b/packages/remix/src/generators/library/library.impl.spec.ts
@@ -34,7 +34,7 @@ describe('Remix Library Generator', () => {
         ],
       }
     `);
-  });
+  }, 25_000);
 
   describe('Standalone Project Repo', () => {
     it('should update the tsconfig paths correctly', async () => {
@@ -58,6 +58,121 @@ describe('Remix Library Generator', () => {
         '~/*'
       );
     });
+  });
+
+  describe('--unitTestRunner', () => {
+    it('should not create config files when unitTestRunner=none', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+      // ACT
+      await libraryGenerator(tree, {
+        name: 'test',
+        style: 'css',
+        unitTestRunner: 'none',
+      });
+
+      // ASSERT
+      expect(tree.exists(`libs/test/jest.config.ts`)).toBeFalsy();
+      expect(tree.exists(`libs/test/vite.config.ts`)).toBeFalsy();
+    });
+
+    it('should create the correct config files for testing with jest', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+      // ACT
+      await libraryGenerator(tree, {
+        name: 'test',
+        style: 'css',
+        unitTestRunner: 'jest',
+      });
+
+      // ASSERT
+      expect(tree.read('libs/test/jest.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        export default {
+          setupFilesAfterEnv: ['./src/test-setup.ts'],
+          displayName: 'test',
+          preset: '../../jest.preset.js',
+          transform: {
+            '^(?!.*\\\\\\\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+            '^.+\\\\\\\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+          },
+          moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+          coverageDirectory: '../../coverage/libs/test',
+        };
+        "
+      `);
+      expect(tree.read('libs/test/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { installGlobals } from '@remix-run/node';
+        import '@testing-library/jest-dom/extend-expect';
+        installGlobals();
+        "
+      `);
+    });
+
+    it('should create the correct config files for testing with vitest', async () => {
+      // ARRANGE
+      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+      // ACT
+      await libraryGenerator(tree, {
+        name: 'test',
+        style: 'css',
+        unitTestRunner: 'vitest',
+      });
+
+      // ASSERT
+      expect(tree.read('libs/test/vite.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/// <reference types=\\"vitest\\" />
+        import react from '@vitejs/plugin-react';
+        import { defineConfig } from 'vite';
+        import viteTsConfigPaths from 'vite-tsconfig-paths';
+
+        export default defineConfig({
+          cacheDir: '../../node_modules/.vite/test',
+
+          plugins: [
+            react(),
+            viteTsConfigPaths({
+              root: '../../',
+            }),
+          ],
+
+          // Uncomment this if you are using workers.
+          // worker: {
+          //  plugins: [
+          //    viteTsConfigPaths({
+          //      root: '../../',
+          //    }),
+          //  ],
+          // },
+
+          test: {
+            setupFiles: ['./src/test-setup.ts'],
+            globals: true,
+            cache: {
+              dir: '../../node_modules/.vitest',
+            },
+            environment: 'jsdom',
+            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+          },
+        });
+        "
+      `);
+
+      expect(tree.read('libs/test/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { installGlobals } from '@remix-run/node';
+        import '@testing-library/jest-dom/extend-expect';
+        installGlobals();
+        "
+      `);
+    }, 25_000);
   });
 
   // TODO(Colum): Unskip this when buildable is investigated correctly

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -1,9 +1,10 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, GeneratorCallback, runTasksInSerial } from '@nx/devkit';
 import { Linter } from '@nx/linter';
-import { libraryGenerator } from '@nx/react/src/generators/library/library';
+import { libraryGenerator } from '@nx/react';
 import {
   addTsconfigEntryPoints,
+  addUnitTestingSetup,
   normalizeOptions,
   updateBuildableConfig,
 } from './lib';
@@ -16,7 +17,7 @@ export default async function (tree: Tree, schema: NxRemixGeneratorSchema) {
   const libGenTask = await libraryGenerator(tree, {
     name: options.name,
     style: options.style,
-    unitTestRunner: 'jest',
+    unitTestRunner: options.unitTestRunner,
     tags: options.tags,
     importPath: options.importPath,
     directory: options.directory,
@@ -27,6 +28,11 @@ export default async function (tree: Tree, schema: NxRemixGeneratorSchema) {
     buildable: options.buildable,
   });
   tasks.push(libGenTask);
+
+  if (options.unitTestRunner && options.unitTestRunner !== 'none') {
+    const pkgInstallTask = addUnitTestingSetup(tree, options);
+    tasks.push(pkgInstallTask);
+  }
 
   addTsconfigEntryPoints(tree, options);
 

--- a/packages/remix/src/generators/library/schema.d.ts
+++ b/packages/remix/src/generators/library/schema.d.ts
@@ -7,6 +7,7 @@ export interface NxRemixGeneratorSchema {
   tags?: string;
   importPath?: string;
   buildable?: boolean;
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   js?: boolean;
   skipFormat?: boolean;
 }

--- a/packages/remix/src/generators/library/schema.json
+++ b/packages/remix/src/generators/library/schema.json
@@ -33,16 +33,20 @@
     "style": {
       "type": "string",
       "description": "Generate a stylesheet",
-      "enum": [
-        "none",
-        "css"
-      ],
+      "enum": ["none", "css"],
       "default": "css"
     },
     "buildable": {
       "type": "boolean",
       "description": "Should the library be buildable?",
       "default": false
+    },
+    "unitTestRunner": {
+      "type": "string",
+      "enum": ["jest", "vitest", "none"],
+      "description": "Test Runner to use for Unit Tests",
+      "x-prompt": "What test runner should be used?",
+      "default": "vitest"
     },
     "importPath": {
       "type": "string",
@@ -60,7 +64,5 @@
       "x-priority": "internal"
     }
   },
-  "required": [
-    "name"
-  ]
+  "required": ["name"]
 }

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -34,7 +34,7 @@ describe('route', () => {
     expect(
       tree.exists('apps/demo/app/styles/path/to/example.css')
     ).toBeTruthy();
-  });
+  }, 25_000);
 
   it('should support --style=none', async () => {
     await applicationGenerator(tree, { name: 'demo' });

--- a/packages/remix/src/utils/versions.ts
+++ b/packages/remix/src/utils/versions.ts
@@ -8,6 +8,9 @@ export const typesReactVersion = '^18.0.25';
 export const typesReactDomVersion = '^18.0.8';
 export const eslintVersion = '^8.27.0';
 export const typescriptVersion = '^4.8.4';
+export const testingLibraryReactVersion = '^14.0.0';
+export const testingLibraryJestDomVersion = '^5.16.5';
+export const testingLibraryUserEventsVersion = '^14.4.3';
 
 export function getRemixVersion(tree: Tree): string {
   return getPackageVersion(tree, '@remix-run/dev') ?? remixVersion;


### PR DESCRIPTION
We generate Remix libs with jest for unit testing

We should offer users a choice of unit test runners between: jest, vitest, none 
