### PR TITLE
feat(remix): add setup-tailwind generator

### DIFF
--- a/packages/remix/generators.json
+++ b/packages/remix/generators.json
@@ -55,6 +55,11 @@
       "schema": "./src/generators/style/schema.json",
       "description": "Generates a new stylesheet and adds it to an existing route"
     },
+    "setup-tailwind": {
+      "implementation": "./src/generators/setup-tailwind/setup-tailwind.impl",
+      "schema": "./src/generators/setup-tailwind/schema.json",
+      "description": "Generates a TailwindCSS configuration for the Remix application"
+    },
     "meta": {
       "implementation": "./src/generators/meta/meta.impl",
       "schema": "./src/generators/meta/schema.json",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -7,7 +7,8 @@
     "@nx/devkit": "^16.0.3",
     "@nx/js": "^16.0.3",
     "@nx/react": "^16.0.3",
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "@phenomnomnominal/tsquery": "^5.0.1"
   },
   "ng-update": {
     "requirements": {},

--- a/packages/remix/src/generators/setup-tailwind/__snapshots__/setup-tailwind.impl.spec.ts.snap
+++ b/packages/remix/src/generators/setup-tailwind/__snapshots__/setup-tailwind.impl.spec.ts.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`setup-tailwind generator should add a js tailwind config to an application correctly 1`] = `
+"import { createGlobPatternsForDependencies } from '@nx/react/tailwind';
+export default {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx}',
+    ...createGlobPatternsForDependencies(__dirname),
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+"
+`;
+
+exports[`setup-tailwind generator should add a js tailwind config to an application correctly 2`] = `
+"@tailwind base;
+@tailwind components;
+@tailwind utilities;
+"
+`;
+
+exports[`setup-tailwind generator should add a js tailwind config to an application correctly 3`] = `
+"import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+import styles from './tailwind.css';
+export const links = () => [{ rel: 'stylesheet', href: styles }];
+export const meta = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`setup-tailwind generator should add a js tailwind config to an application correctly 4`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  tailwind: true,
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`setup-tailwind generator should add a tailwind config to an application correctly 1`] = `
+"import type { Config } from \\"tailwindcss\\";
+import { createGlobPatternsForDependencies } from '@nx/react/tailwind';
+
+export default {
+  content: [
+    \\"./app/**/*.{js,jsx,ts,tsx}\\",
+    ...createGlobPatternsForDependencies(__dirname)
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;
+"
+`;
+
+exports[`setup-tailwind generator should add a tailwind config to an application correctly 2`] = `
+"@tailwind base;
+@tailwind components;
+@tailwind utilities;
+"
+`;
+
+exports[`setup-tailwind generator should add a tailwind config to an application correctly 3`] = `
+"import type { LinksFunction, MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+import styles from './tailwind.css';
+export const links: LinksFunction = () => [{ rel: 'stylesheet', href: styles }];
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`setup-tailwind generator should add a tailwind config to an application correctly 4`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  tailwind: true,
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;

--- a/packages/remix/src/generators/setup-tailwind/files/app/tailwind.css__tpl__
+++ b/packages/remix/src/generators/setup-tailwind/files/app/tailwind.css__tpl__
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/remix/src/generators/setup-tailwind/files/tailwind.config.ts__tpl__
+++ b/packages/remix/src/generators/setup-tailwind/files/tailwind.config.ts__tpl__
@@ -1,0 +1,13 @@
+import type { Config } from "tailwindcss";
+import { createGlobPatternsForDependencies } from '@nx/react/tailwind';
+
+export default {
+  content: [
+    "./app/**/*.{js,jsx,ts,tsx}",
+    ...createGlobPatternsForDependencies(__dirname)
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/packages/remix/src/generators/setup-tailwind/lib/index.ts
+++ b/packages/remix/src/generators/setup-tailwind/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './update-remix-config';

--- a/packages/remix/src/generators/setup-tailwind/lib/update-remix-config.spec.ts
+++ b/packages/remix/src/generators/setup-tailwind/lib/update-remix-config.spec.ts
@@ -1,0 +1,79 @@
+import { stripIndents } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { updateRemixConfig } from './update-remix-config';
+
+describe('updateRemixConfig', () => {
+  it('should add tailwind property to an existing config that doesnt have it', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      `remix.config.js`,
+      stripIndents`module.exports = {
+      ignoredRouteFiles: ['**/.*'],
+      watchPaths: ['../../libs']
+    };`
+    );
+
+    // ACT
+    updateRemixConfig(tree, '.');
+
+    // ASSERT
+    expect(tree.read('remix.config.js', 'utf-8')).toMatchInlineSnapshot(`
+      "module.exports = {
+      tailwind: true,
+      ignoredRouteFiles: ['**/.*'],
+      watchPaths: ['../../libs']
+      };"
+    `);
+  });
+
+  it('should update tailwind property if the config has it and set to false', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      `remix.config.js`,
+      stripIndents`module.exports = {
+      ignoredRouteFiles: ['**/.*'],
+      tailwind: false,
+      watchPaths: ['../../libs']
+    };`
+    );
+
+    // ACT
+    updateRemixConfig(tree, '.');
+
+    // ASSERT
+    expect(tree.read('remix.config.js', 'utf-8')).toMatchInlineSnapshot(`
+      "module.exports = {
+      ignoredRouteFiles: ['**/.*'],
+      tailwind: true,
+      watchPaths: ['../../libs']
+      };"
+    `);
+  });
+
+  it('should not update tailwind property if the config has it and set to true', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      `remix.config.js`,
+      stripIndents`module.exports = {
+      ignoredRouteFiles: ['**/.*'],
+      tailwind: true,
+      watchPaths: ['../../libs']
+    };`
+    );
+
+    // ACT
+    updateRemixConfig(tree, '.');
+
+    // ASSERT
+    expect(tree.read('remix.config.js', 'utf-8')).toMatchInlineSnapshot(`
+      "module.exports = {
+      ignoredRouteFiles: ['**/.*'],
+      tailwind: true,
+      watchPaths: ['../../libs']
+      };"
+    `);
+  });
+});

--- a/packages/remix/src/generators/setup-tailwind/lib/update-remix-config.ts
+++ b/packages/remix/src/generators/setup-tailwind/lib/update-remix-config.ts
@@ -1,0 +1,52 @@
+import { joinPathFragments, type Tree } from '@nx/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+export function updateRemixConfig(tree: Tree, projectRoot: string) {
+  const pathToRemixConfig = joinPathFragments(projectRoot, 'remix.config.js');
+
+  if (!tree.exists(pathToRemixConfig)) {
+    throw new Error(
+      `Could not find "${pathToRemixConfig}". Please ensure a "remix.config.js" exists at the root of your project.`
+    );
+  }
+
+  const fileContents = tree.read(pathToRemixConfig, 'utf-8');
+
+  const REMIX_CONFIG_OBJECT_SELECTOR =
+    'PropertyAccessExpression:has(Identifier[name=module], Identifier[name=exports])~ObjectLiteralExpression';
+  const ast = tsquery.ast(fileContents);
+
+  const nodes = tsquery(ast, REMIX_CONFIG_OBJECT_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (nodes.length === 0) {
+    throw new Error(`Remix Config is not valid, unable to update the file.`);
+  }
+
+  const configObjectNode = nodes[0];
+
+  const propertyNodes = tsquery(configObjectNode, 'PropertyAssignment', {
+    visitAllChildren: true,
+  });
+
+  for (const propertyNode of propertyNodes) {
+    const nodeText = propertyNode.getText();
+    if (nodeText.includes('tailwind') && nodeText.includes('true')) {
+      return;
+    } else if (nodeText.includes('tailwind') && nodeText.includes('false')) {
+      const updatedFileContents = `${fileContents.slice(
+        0,
+        propertyNode.getStart()
+      )}tailwind: true${fileContents.slice(propertyNode.getEnd())}`;
+      tree.write(pathToRemixConfig, updatedFileContents);
+      return;
+    }
+  }
+
+  const updatedFileContents = `${fileContents.slice(
+    0,
+    configObjectNode.getStart() + 1
+  )}\ntailwind: true,${fileContents.slice(configObjectNode.getStart() + 1)}`;
+
+  tree.write(pathToRemixConfig, updatedFileContents);
+}

--- a/packages/remix/src/generators/setup-tailwind/schema.d.ts
+++ b/packages/remix/src/generators/setup-tailwind/schema.d.ts
@@ -1,0 +1,5 @@
+export interface SetupTailwindSchema {
+  project: string;
+  js?: boolean;
+  skipFormat?: boolean;
+}

--- a/packages/remix/src/generators/setup-tailwind/schema.json
+++ b/packages/remix/src/generators/setup-tailwind/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxRemixTailwind",
+  "title": "Add TailwindCSS to a Remix App",
+  "type": "object",
+  "examples": [
+    {
+      "command": "g setup-tailwind --project=myapp",
+      "description": "Generate a TailwindCSS config for your Remix app"
+    }
+  ],
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project to add tailwind to",
+      "$default": {
+        "$source": "projectName"
+      },
+      "x-prompt": "What project would you like to add Tailwind to?",
+      "pattern": "^[a-zA-Z].*$"
+    },
+    "js": {
+      "type": "boolean",
+      "description": "Generate a JavaScript config file instead of a TypeScript config file",
+      "default": false
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files after generator runs",
+      "default": false,
+      "x-priority": "internal"
+    }
+  },
+  "required": ["project"]
+}

--- a/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.spec.ts
+++ b/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.spec.ts
@@ -1,0 +1,53 @@
+import { readJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import applicationGenerator from '../application/application.impl';
+import setupTailwind from './setup-tailwind.impl';
+
+describe('setup-tailwind generator', () => {
+  it('should add a tailwind config to an application correctly', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    await applicationGenerator(tree, {
+      name: 'test',
+      rootProject: true,
+    });
+
+    // ACT
+    await setupTailwind(tree, { project: 'test' });
+
+    // ASSERT
+    expect(tree.exists('tailwind.config.ts')).toBeTruthy();
+    expect(tree.read('tailwind.config.ts', 'utf-8')).toMatchSnapshot();
+    expect(tree.exists('app/tailwind.css')).toBeTruthy();
+    expect(tree.read('app/tailwind.css', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('app/root.tsx', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('remix.config.js', 'utf-8')).toMatchSnapshot();
+    expect(
+      readJson(tree, 'package.json').dependencies['tailwindcss']
+    ).toBeTruthy();
+  });
+
+  it('should add a js tailwind config to an application correctly', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    await applicationGenerator(tree, {
+      name: 'test',
+      js: true,
+      rootProject: true,
+    });
+
+    // ACT
+    await setupTailwind(tree, { project: 'test', js: true });
+
+    // ASSERT
+    expect(tree.exists('tailwind.config.js')).toBeTruthy();
+    expect(tree.read('tailwind.config.js', 'utf-8')).toMatchSnapshot();
+    expect(tree.exists('app/tailwind.css')).toBeTruthy();
+    expect(tree.read('app/tailwind.css', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('app/root.js', 'utf-8')).toMatchSnapshot();
+    expect(tree.read('remix.config.js', 'utf-8')).toMatchSnapshot();
+    expect(
+      readJson(tree, 'package.json').dependencies['tailwindcss']
+    ).toBeTruthy();
+  });
+});

--- a/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.ts
+++ b/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.ts
@@ -1,0 +1,68 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  generateFiles,
+  installPackagesTask,
+  joinPathFragments,
+  readProjectConfiguration,
+  toJS,
+  type Tree,
+} from '@nx/devkit';
+
+import { upsertLinksFunction } from '../../utils/upsert-links-function';
+import { tailwindVersion } from '../../utils/versions';
+import { updateRemixConfig } from './lib';
+import type { SetupTailwindSchema } from './schema';
+
+export default async function setupTailwind(
+  tree: Tree,
+  options: SetupTailwindSchema
+) {
+  const project = readProjectConfiguration(tree, options.project);
+  if (project.projectType !== 'application') {
+    throw new Error(
+      `Project "${options.project}" is not an application. Please ensure the project is an application.`
+    );
+  }
+
+  updateRemixConfig(tree, project.root);
+
+  generateFiles(tree, joinPathFragments(__dirname, 'files'), project.root, {
+    tpl: '',
+  });
+
+  if (options.js) {
+    tree.rename(
+      joinPathFragments(project.root, 'app/root.js'),
+      joinPathFragments(project.root, 'app/root.tsx')
+    );
+  }
+  const pathToRoot = joinPathFragments(project.root, 'app/root.tsx');
+  upsertLinksFunction(
+    tree,
+    pathToRoot,
+    'styles',
+    './tailwind.css',
+    `{ rel: "stylesheet", href: styles }`
+  );
+
+  addDependenciesToPackageJson(
+    tree,
+    {
+      tailwindcss: tailwindVersion,
+    },
+    {}
+  );
+
+  if (options.js) {
+    toJS(tree);
+  }
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+
+  return () => {
+    installPackagesTask(tree);
+  };
+}

--- a/packages/remix/src/utils/upsert-links-function.spec.ts
+++ b/packages/remix/src/utils/upsert-links-function.spec.ts
@@ -1,0 +1,61 @@
+import { stripIndents } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { upsertLinksFunction } from './upsert-links-function';
+
+describe('upsertLinksFunctions', () => {
+  it('should add the imports and the link function when it does not exist', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(`root.tsx`, ``);
+
+    // ACT
+    upsertLinksFunction(
+      tree,
+      'root.tsx',
+      'styles',
+      './tailwind.css',
+      '{ rel: "stylesheet", href: styles }'
+    );
+
+    // ASSERT
+    expect(tree.read('root.tsx', 'utf-8')).toMatchInlineSnapshot(`
+      "import type { LinksFunction } from '@remix-run/node';
+      import styles from \\"./tailwind.css\\";
+      export const links: LinksFunction = () => [
+      { rel: \\"stylesheet\\", href: styles },
+      ];"
+    `);
+  });
+
+  it('should update an existing links function with the new object', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      `root.tsx`,
+      stripIndents`import type { LinksFunction } from '@remix-run/node';
+
+    export const links: LinksFunction = () => [
+      { rel: "icon", href: "/favicon.png" type: "image/png" }
+    `
+    );
+
+    // ACT
+    upsertLinksFunction(
+      tree,
+      'root.tsx',
+      'styles',
+      './tailwind.css',
+      '{ rel: "stylesheet", href: styles }'
+    );
+
+    // ASSERT
+    expect(tree.read('root.tsx', 'utf-8')).toMatchInlineSnapshot(`
+      "import type { LinksFunction } from '@remix-run/node';
+      import styles from \\"./tailwind.css\\";
+
+      export const links: LinksFunction = () => [
+      { rel: \\"stylesheet\\", href: styles },
+      { rel: \\"icon\\", href: \\"/favicon.png\\" type: \\"image/png\\" }"
+    `);
+  });
+});

--- a/packages/remix/src/utils/upsert-links-function.ts
+++ b/packages/remix/src/utils/upsert-links-function.ts
@@ -1,0 +1,51 @@
+import { stripIndents, type Tree } from '@nx/devkit';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { insertImport } from './insert-import';
+import { insertStatementAfterImports } from './insert-statement-after-imports';
+
+export function upsertLinksFunction(
+  tree: Tree,
+  filePath: string,
+  importName: string,
+  importPath: string,
+  linkObject: string
+) {
+  insertImport(tree, filePath, 'LinksFunction', '@remix-run/node', {
+    typeOnly: true,
+  });
+  insertStatementAfterImports(
+    tree,
+    filePath,
+    stripIndents`import ${importName} from "${importPath}";`
+  );
+
+  const fileContents = tree.read(filePath, 'utf-8');
+  const LINKS_FUNCTION_SELECTOR =
+    'VariableDeclaration:has(TypeReference > Identifier[name=LinksFunction])';
+  const ast = tsquery.ast(fileContents);
+
+  const linksFunctionNodes = tsquery(ast, LINKS_FUNCTION_SELECTOR, {
+    visitAllChildren: true,
+  });
+  if (linksFunctionNodes.length === 0) {
+    insertStatementAfterImports(
+      tree,
+      filePath,
+      stripIndents`export const links: LinksFunction = () => [
+  ${linkObject},
+];`
+    );
+  } else {
+    const linksArrayNodes = tsquery(
+      linksFunctionNodes[0],
+      'ArrayLiteralExpression',
+      { visitAllChildren: true }
+    );
+    const arrayNode = linksArrayNodes[0];
+    const updatedFileContents = `${fileContents.slice(
+      0,
+      arrayNode.getStart() + 1
+    )}\n${linkObject},${fileContents.slice(arrayNode.getStart() + 1)}`;
+    tree.write(filePath, updatedFileContents);
+  }
+}

--- a/packages/remix/src/utils/versions.ts
+++ b/packages/remix/src/utils/versions.ts
@@ -8,10 +8,7 @@ export const typesReactVersion = '^18.0.25';
 export const typesReactDomVersion = '^18.0.8';
 export const eslintVersion = '^8.27.0';
 export const typescriptVersion = '^4.8.4';
-export const testingLibraryReactVersion = '^14.0.0';
-export const testingLibraryJestDomVersion = '^5.16.5';
-export const testingLibraryUserEventsVersion = '^14.4.3';
-
+export const tailwindVersion = '^3.3.0';
 export const testingLibraryReactVersion = '^14.0.0';
 export const testingLibraryJestDomVersion = '^5.16.5';
 export const testingLibraryUserEventsVersion = '^14.4.3';


### PR DESCRIPTION
We currently do not have a generator that creates a TailwindCSS setup for an application

The process of doing this manually is a little involved

1. Add a `tailwind: true` property to the remix.config.js
2. Install + Init Tailwind with `npx tailwindcss init --ts` - this has to be done in the correct directory if using integrated repos
3. Add a LinksFunction to root.tsx
4. Add the tailwind.css file with the tailwind directives

We can do this in one command with a generator.

This PR adds a generator to do that.
It also adds a util function for adding or updating a LinksFunction
