### PR TITLE
fix(rspack): lock version to 0.1.11

### DIFF
--- a/packages/rspack/src/utils/versions.ts
+++ b/packages/rspack/src/utils/versions.ts
@@ -1,8 +1,8 @@
-export const rspackCoreVersion = '~0.1.0';
-export const rspackDevServerVersion = '~0.1.0';
+export const rspackCoreVersion = '0.1.11';
+export const rspackDevServerVersion = '0.1.11';
 
-export const rspackPluginMinifyVersion = '~0.1.0';
-export const rspackLessLoaderVersion = '~0.1.0';
+export const rspackPluginMinifyVersion = '0.1.11';
+export const rspackLessLoaderVersion = '^0.0.22';
 
 export const reactVersion = '~18.2.0';
 export const reactDomVersion = '~18.2.0';


### PR DESCRIPTION
Locking `@rspack/*` version to `0.1.11` [because `0.1.12` is broken](https://github.com/web-infra-dev/rspack/issues/3270).