### PR TITLE
feat(remix): app should generate a cypress e2e project

### DIFF
--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -69,6 +69,34 @@ describe('Remix Application', () => {
         `);
       });
     });
+
+    describe('--e2eTestRunner', () => {
+      it('should generate an e2e application for the app', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace();
+
+        // ACT
+        await applicationGenerator(tree, {
+          name: 'test',
+          e2eTestRunner: 'cypress',
+          rootProject: true,
+        });
+
+        // ASSERT
+        expectTargetsToBeCorrect(tree, '.');
+
+        expect(tree.read('e2e/cypress.config.ts', 'utf-8'))
+          .toMatchInlineSnapshot(`
+          "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+          import { defineConfig } from 'cypress';
+
+          export default defineConfig({
+            e2e: nxE2EPreset(__dirname),
+          });
+          "
+        `);
+      });
+    });
   });
 
   describe('Integrated Repo', () => {
@@ -189,6 +217,33 @@ describe('Remix Application', () => {
           "import { installGlobals } from '@remix-run/node';
           import '@testing-library/jest-dom/extend-expect';
           installGlobals();
+          "
+        `);
+      });
+    });
+
+    describe('--e2eTestRunner', () => {
+      it('should generate an e2e application for the app', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+        // ACT
+        await applicationGenerator(tree, {
+          name: 'test',
+          e2eTestRunner: 'cypress',
+        });
+
+        // ASSERT
+        expectTargetsToBeCorrect(tree, 'apps/test');
+
+        expect(tree.read('apps/test-e2e/cypress.config.ts', 'utf-8'))
+          .toMatchInlineSnapshot(`
+          "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+          import { defineConfig } from 'cypress';
+
+          export default defineConfig({
+            e2e: nxE2EPreset(__dirname),
+          });
           "
         `);
       });

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -25,6 +25,7 @@ import {
   typesReactDomVersion,
   typesReactVersion,
 } from '../../utils/versions';
+import cypressGenerator from '../cypress/cypress.impl';
 import { normalizeOptions, updateViteTestConfig } from './lib';
 import { NxRemixGeneratorSchema } from './schema';
 
@@ -175,6 +176,14 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
   } else {
     // Otherwise, extract the tsconfig.base.json from tsconfig.json so we can share settings.
     extractTsConfigBase(tree);
+  }
+
+  if (options.e2eTestRunner === 'cypress') {
+    const cypressTasks = await cypressGenerator(tree, {
+      project: options.projectName,
+      name: options.rootProject ? `e2e` : `${options.projectName}-e2e`,
+    });
+    tasks.push(cypressTasks);
   }
 
   if (!options.skipFormat) {

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -4,6 +4,7 @@ export interface NxRemixGeneratorSchema {
   js?: boolean;
   directory?: string;
   unitTestRunner?: 'vitest' | 'none';
+  e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;
   rootProject?: boolean;
 }

--- a/packages/remix/src/generators/application/schema.json
+++ b/packages/remix/src/generators/application/schema.json
@@ -31,6 +31,12 @@
       "description": "Test runner to use for unit tests.",
       "x-prompt": "What unit test runner should be used?"
     },
+    "e2eTestRunner": {
+      "type": "string",
+      "enum": ["cypress", "none"],
+      "default": "cypress",
+      "description": "Test runner to use for e2e tests"
+    },
     "tags": {
       "type": "string",
       "description": "Add tags to the project (used for linting)",

--- a/packages/remix/tsconfig.spec.json
+++ b/packages/remix/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "resolveJsonModule": true
   },
   "include": [
     "**/*.test.ts",


### PR DESCRIPTION
We should generate an e2e app by default for remix apps but offer users a flag to opt out
