### PR TITLE
chore(remix): refactor testing config utils

### DIFF
--- a/packages/remix/src/generators/application/lib/update-vite-test-config.ts
+++ b/packages/remix/src/generators/application/lib/update-vite-test-config.ts
@@ -5,14 +5,14 @@ import {
   type Tree,
 } from '@nx/devkit';
 import {
+  updateViteTestIncludes,
+  updateViteTestSetup,
+} from '../../../utils/testing-config-utils';
+import {
   testingLibraryJestDomVersion,
   testingLibraryReactVersion,
   testingLibraryUserEventsVersion,
 } from '../../../utils/versions';
-import {
-  updateViteTestIncludes,
-  updateViteTestSetup,
-} from '../../../utils/vitest-config-utils';
 
 export function updateViteTestConfig(tree: Tree, pathToRoot: string) {
   const pathToViteConfig = joinPathFragments(pathToRoot, 'vite.config.ts');

--- a/packages/remix/src/generators/library/lib/add-unit-testing.ts
+++ b/packages/remix/src/generators/library/lib/add-unit-testing.ts
@@ -5,7 +5,10 @@ import {
   stripIndents,
   type Tree,
 } from '@nx/devkit';
-import { tsquery } from '@phenomnomnominal/tsquery';
+import {
+  updateJestTestSetup,
+  updateViteTestSetup,
+} from '../../../utils/testing-config-utils';
 import {
   testingLibraryJestDomVersion,
   testingLibraryReactVersion,
@@ -35,10 +38,10 @@ export function addUnitTestingSetup(tree: Tree, options: RemixLibraryOptions) {
 
   if (options.unitTestRunner === 'vitest') {
     const pathToVitestConfig = joinPathFragments(projectRoot, `vite.config.ts`);
-    updateViteTestSetup(tree, pathToVitestConfig);
+    updateViteTestSetup(tree, pathToVitestConfig, './src/test-setup.ts');
   } else if (options.unitTestRunner === 'jest') {
     const pathToJestConfig = joinPathFragments(projectRoot, `jest.config.ts`);
-    updateJestTestSetup(tree, pathToJestConfig);
+    updateJestTestSetup(tree, pathToJestConfig, './src/test-setup.ts');
   }
 
   return addDependenciesToPackageJson(
@@ -50,84 +53,4 @@ export function addUnitTestingSetup(tree: Tree, options: RemixLibraryOptions) {
       '@testing-library/user-event': testingLibraryUserEventsVersion,
     }
   );
-}
-
-function updateViteTestSetup(tree: Tree, pathToViteConfig: string) {
-  const fileContents = tree.read(pathToViteConfig, 'utf-8');
-
-  const ast = tsquery.ast(fileContents);
-
-  const TEST_SETUPFILES_SELECTOR =
-    'PropertyAssignment:has(Identifier[name=test]) PropertyAssignment:has(Identifier[name=setupFiles])';
-  const nodes = tsquery(ast, TEST_SETUPFILES_SELECTOR, {
-    visitAllChildren: true,
-  });
-
-  if (nodes.length === 0) {
-    const TEST_CONFIG_SELECTOR =
-      'PropertyAssignment:has(Identifier[name=test]) > ObjectLiteralExpression';
-    const testConfigNodes = tsquery(ast, TEST_CONFIG_SELECTOR, {
-      visitAllChildren: true,
-    });
-    const updatedFileContents = stripIndents`${fileContents.slice(
-      0,
-      testConfigNodes[0].getStart() + 1
-    )}setupFiles: ['./src/test-setup.ts'],${fileContents.slice(
-      testConfigNodes[0].getStart() + 1
-    )}`;
-    tree.write(pathToViteConfig, updatedFileContents);
-  } else {
-    const arrayNodes = tsquery(nodes[0], 'ArrayLiteralExpression', {
-      visitAllChildren: true,
-    });
-    if (arrayNodes.length !== 0) {
-      const updatedFileContents = stripIndents`${fileContents.slice(
-        0,
-        arrayNodes[0].getStart() + 1
-      )}'./src/test-setup.ts',${fileContents.slice(
-        arrayNodes[0].getStart() + 1
-      )}`;
-
-      tree.write(pathToViteConfig, updatedFileContents);
-    }
-  }
-}
-
-function updateJestTestSetup(tree: Tree, pathToJestConfig: string) {
-  const fileContents = tree.read(pathToJestConfig, 'utf-8');
-
-  const ast = tsquery.ast(fileContents);
-
-  const TEST_SETUPFILES_SELECTOR =
-    'PropertyAssignment:has(Identifier[name=setupFilesAfterEnv])';
-  const nodes = tsquery(ast, TEST_SETUPFILES_SELECTOR, {
-    visitAllChildren: true,
-  });
-
-  if (nodes.length === 0) {
-    const CONFIG_SELECTOR = 'ObjectLiteralExpression';
-    const nodes = tsquery(ast, CONFIG_SELECTOR, { visitAllChildren: true });
-
-    const updatedFileContents = stripIndents`${fileContents.slice(
-      0,
-      nodes[0].getStart() + 1
-    )}setupFilesAfterEnv: ['./src/test-setup.ts'],${fileContents.slice(
-      nodes[0].getStart() + 1
-    )}`;
-    tree.write(pathToJestConfig, updatedFileContents);
-  } else {
-    const arrayNodes = tsquery(nodes[0], 'ArrayLiteralExpression', {
-      visitAllChildren: true,
-    });
-    if (arrayNodes.length !== 0) {
-      const updatedFileContents = stripIndents`${fileContents.slice(
-        0,
-        arrayNodes[0].getStart() + 1
-      )}'./src/test-setup.ts',${fileContents.slice(
-        arrayNodes[0].getStart() + 1
-      )}`;
-
-      tree.write(pathToJestConfig, updatedFileContents);
-    }
-  }
 }


### PR DESCRIPTION
Refactor the testing utils file name to be more accurate as it also now contains jest logic which can be used by a future PR where app generator will allow jest to be selected as the unit test runner
