### PR TITLE
feat(remix): add jest support to app generator

### DIFF
--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -258,7 +258,7 @@ exports[`Remix Application Integrated Repo --js should create the application co
 "
 `;
 
-exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing 1`] = `
+exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using jest 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -273,7 +273,37 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing 2`] = `
+exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using jest 2`] = `
+"/* eslint-disable */
+export default {
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  displayName: 'test',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/apps/test',
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using vitest 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using vitest 2`] = `
 "/// <reference types=\\"vitest\\" />
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
@@ -482,7 +512,7 @@ exports[`Remix Application Standalone Project Repo --js should create the applic
 "
 `;
 
-exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing 1`] = `
+exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing using jest 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -497,7 +527,41 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing 2`] = `
+exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing using jest 2`] = `
+"/* eslint-disable */
+export default {
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  displayName: 'test',
+  preset: './jest.preset.js',
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: './coverage/test',
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+    '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
+  ],
+};
+"
+`;
+
+exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing using vitest 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing using vitest 2`] = `
 "/// <reference types=\\"vitest\\" />
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -45,7 +45,7 @@ describe('Remix Application', () => {
     });
 
     describe('--unitTestRunner', () => {
-      it('should generate the correct files for testing', async () => {
+      it('should generate the correct files for testing using vitest', async () => {
         // ARRANGE
         const tree = createTreeWithEmptyWorkspace();
 
@@ -61,6 +61,30 @@ describe('Remix Application', () => {
 
         expect(tree.read('remix.config.js', 'utf-8')).toMatchSnapshot();
         expect(tree.read('vite.config.ts', 'utf-8')).toMatchSnapshot();
+        expect(tree.read('test-setup.ts', 'utf-8')).toMatchInlineSnapshot(`
+          "import { installGlobals } from '@remix-run/node';
+          import '@testing-library/jest-dom/extend-expect';
+          installGlobals();
+          "
+        `);
+      });
+
+      it('should generate the correct files for testing using jest', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace();
+
+        // ACT
+        await applicationGenerator(tree, {
+          name: 'test',
+          unitTestRunner: 'jest',
+          rootProject: true,
+        });
+
+        // ASSERT
+        expectTargetsToBeCorrect(tree, '.');
+
+        expect(tree.read('remix.config.js', 'utf-8')).toMatchSnapshot();
+        expect(tree.read('jest.config.ts', 'utf-8')).toMatchSnapshot();
         expect(tree.read('test-setup.ts', 'utf-8')).toMatchInlineSnapshot(`
           "import { installGlobals } from '@remix-run/node';
           import '@testing-library/jest-dom/extend-expect';
@@ -193,7 +217,7 @@ describe('Remix Application', () => {
     });
 
     describe('--unitTestRunner', () => {
-      it('should generate the correct files for testing', async () => {
+      it('should generate the correct files for testing using vitest', async () => {
         // ARRANGE
         const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
@@ -211,6 +235,34 @@ describe('Remix Application', () => {
         ).toMatchSnapshot();
         expect(
           tree.read('apps/test/vite.config.ts', 'utf-8')
+        ).toMatchSnapshot();
+        expect(tree.read('apps/test/test-setup.ts', 'utf-8'))
+          .toMatchInlineSnapshot(`
+          "import { installGlobals } from '@remix-run/node';
+          import '@testing-library/jest-dom/extend-expect';
+          installGlobals();
+          "
+        `);
+      });
+
+      it('should generate the correct files for testing using jest', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+        // ACT
+        await applicationGenerator(tree, {
+          name: 'test',
+          unitTestRunner: 'jest',
+        });
+
+        // ASSERT
+        expectTargetsToBeCorrect(tree, 'apps/test');
+
+        expect(
+          tree.read('apps/test/remix.config.js', 'utf-8')
+        ).toMatchSnapshot();
+        expect(
+          tree.read('apps/test/jest.config.ts', 'utf-8')
         ).toMatchSnapshot();
         expect(tree.read('apps/test/test-setup.ts', 'utf-8'))
           .toMatchInlineSnapshot(`

--- a/packages/remix/src/generators/application/lib/index.ts
+++ b/packages/remix/src/generators/application/lib/index.ts
@@ -1,2 +1,2 @@
 export * from './normalize-options';
-export * from './update-vite-test-config';
+export * from './update-unit-test-config';

--- a/packages/remix/src/generators/application/lib/update-unit-test-config.ts
+++ b/packages/remix/src/generators/application/lib/update-unit-test-config.ts
@@ -5,6 +5,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import {
+  updateJestTestSetup,
   updateViteTestIncludes,
   updateViteTestSetup,
 } from '../../../utils/testing-config-utils';
@@ -14,8 +15,11 @@ import {
   testingLibraryUserEventsVersion,
 } from '../../../utils/versions';
 
-export function updateViteTestConfig(tree: Tree, pathToRoot: string) {
-  const pathToViteConfig = joinPathFragments(pathToRoot, 'vite.config.ts');
+export function updateUnitTestConfig(
+  tree: Tree,
+  pathToRoot: string,
+  unitTestRunner: 'vitest' | 'jest'
+) {
   const pathToTestSetup = joinPathFragments(pathToRoot, `test-setup.ts`);
   tree.write(
     pathToTestSetup,
@@ -25,12 +29,18 @@ export function updateViteTestConfig(tree: Tree, pathToRoot: string) {
   installGlobals();`
   );
 
-  updateViteTestIncludes(
-    tree,
-    pathToViteConfig,
-    './app/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
-  );
-  updateViteTestSetup(tree, pathToViteConfig, './test-setup.ts');
+  if (unitTestRunner === 'vitest') {
+    const pathToViteConfig = joinPathFragments(pathToRoot, 'vite.config.ts');
+    updateViteTestIncludes(
+      tree,
+      pathToViteConfig,
+      './app/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
+    );
+    updateViteTestSetup(tree, pathToViteConfig, './test-setup.ts');
+  } else if (unitTestRunner === 'jest') {
+    const pathToJestConfig = joinPathFragments(pathToRoot, 'jest.config.ts');
+    updateJestTestSetup(tree, pathToJestConfig, `<rootDir>/test-setup.ts`);
+  }
 
   return addDependenciesToPackageJson(
     tree,

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -3,7 +3,7 @@ export interface NxRemixGeneratorSchema {
   tags?: string;
   js?: boolean;
   directory?: string;
-  unitTestRunner?: 'vitest' | 'none';
+  unitTestRunner?: 'vitest' | 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;
   rootProject?: boolean;

--- a/packages/remix/src/generators/application/schema.json
+++ b/packages/remix/src/generators/application/schema.json
@@ -26,14 +26,21 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["vitest", "none"],
+      "enum": [
+        "vitest",
+        "jest",
+        "none"
+      ],
       "default": "vitest",
       "description": "Test runner to use for unit tests.",
       "x-prompt": "What unit test runner should be used?"
     },
     "e2eTestRunner": {
       "type": "string",
-      "enum": ["cypress", "none"],
+      "enum": [
+        "cypress",
+        "none"
+      ],
       "default": "cypress",
       "description": "Test runner to use for e2e tests"
     },


### PR DESCRIPTION
Add jest support to Application generator

This puts it inline with supporting the major testing tooling we already offer for Angular, React etc
