### PR TITLE
fix(remix): export new generators from package public api

### DIFF
--- a/packages/remix/src/index.ts
+++ b/packages/remix/src/index.ts
@@ -1,11 +1,13 @@
 export * from './generators/action/action.impl';
 export * from './generators/application/application.impl';
 export * from './generators/cypress/cypress.impl';
+export * from './generators/error-boundary/error-boundary.impl';
 export * from './generators/library/library.impl';
 export * from './generators/loader/loader.impl';
 export * from './generators/meta/meta.impl';
 export * from './generators/preset/preset.impl';
 export * from './generators/resource-route/resource-route.impl';
 export * from './generators/route/route.impl';
+export * from './generators/setup-tailwind/setup-tailwind.impl';
 export * from './generators/style/style.impl';
 export { createWatchPaths } from './utils/create-watch-paths';


### PR DESCRIPTION

Adding the generators that have been recently created to the public api as they were missed during those PRs
