### PR TITLE
fix(rspack): add missing license-webpack-plugin dependency

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -26,6 +26,7 @@
     "ajv": "^8.12.0",
     "ajv-keywords": "5.1.0",
     "less-loader": "11.1.0",
+    "license-webpack-plugin": "^4.0.2",
     "sass-loader": "^12.2.0",
     "stylus-loader": "^7.1.0"
   },


### PR DESCRIPTION
The dependency is missing making the plugin not usable.

The problem was introduced here: https://github.com/nrwl/nx-labs/pull/230