### PR TITLE
fix(remix): fix error when creating new workspaces using remix preset

### DIFF
--- a/packages/remix/.eslintrc.json
+++ b/packages/remix/.eslintrc.json
@@ -4,7 +4,9 @@
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
     },
     {
       "files": ["*.ts", "*.tsx"],

--- a/packages/remix/src/utils/testing-config-utils.ts
+++ b/packages/remix/src/utils/testing-config-utils.ts
@@ -1,6 +1,5 @@
 import { stripIndents, type Tree } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
-import { tsquery } from '@phenomnomnominal/tsquery';
 
 let tsModule: typeof import('typescript');
 
@@ -12,6 +11,7 @@ export function updateViteTestSetup(
   if (!tsModule) {
     tsModule = ensureTypescript();
   }
+  const { tsquery } = require('@phenomnomnominal/tsquery');
   const fileContents = tree.read(pathToViteConfig, 'utf-8');
 
   const ast = tsquery.ast(fileContents);
@@ -61,6 +61,7 @@ export function updateJestTestSetup(
   if (!tsModule) {
     tsModule = ensureTypescript();
   }
+  const { tsquery } = require('@phenomnomnominal/tsquery');
   const fileContents = tree.read(pathToJestConfig, 'utf-8');
 
   const ast = tsquery.ast(fileContents);
@@ -107,6 +108,7 @@ export function updateViteTestIncludes(
   if (!tsModule) {
     tsModule = ensureTypescript();
   }
+  const { tsquery } = require('@phenomnomnominal/tsquery');
   const fileContents = tree.read(pathToViteConfig, 'utf-8');
 
   const ast = tsquery.ast(fileContents);


### PR DESCRIPTION
Importing `tsquery` results in an error if `typescript` is not installed to the workspace yet. This PR ensures `typecript` is available before importing `tsquery`.

Fixes: https://github.com/nrwl/nx/issues/17762