### PR TITLE
feat(remix): set correct defaults for @nx/remix:preset to match @nx/remix:app defaults

### DIFF
--- a/packages/remix/src/generators/preset/lib/normalize-options.ts
+++ b/packages/remix/src/generators/preset/lib/normalize-options.ts
@@ -5,6 +5,9 @@ export interface NormalizedSchema extends RemixGeneratorSchema {
   appName: string;
   projectRoot: string;
   parsedTags: string[];
+  unitTestRunner?: 'jest' | 'none' | 'vitest';
+  e2eTestRunner?: 'cypress' | 'none';
+  js?: boolean;
 }
 
 export function normalizeOptions(

--- a/packages/remix/src/generators/preset/preset.impl.ts
+++ b/packages/remix/src/generators/preset/preset.impl.ts
@@ -18,6 +18,9 @@ export default async function (tree: Tree, _options: RemixGeneratorSchema) {
     tags: options.tags,
     skipFormat: true,
     rootProject: true,
+    unitTestRunner: options.unitTestRunner ?? 'vitest',
+    e2eTestRunner: options.e2eTestRunner ?? 'cypress',
+    js: options.js ?? false,
   });
   tasks.push(appGenTask);
 


### PR DESCRIPTION
This PR makes Vitest the default when running `npx create-nx-workspace --preset=@nx/remix`. User can pass `--unitTestRunner=jest` if they want to use Jest instead. 

The e2e test runner is also correctly defaulted to Cypress, just like running the app generator.

Lastly, also added `--js` flag if user choose to not use TypeScript.