### PR TITLE
fix(remix): set up e2e so it runs out of the box

### DIFF
--- a/packages/remix/src/generators/cypress/cypress.impl.spec.ts
+++ b/packages/remix/src/generators/cypress/cypress.impl.spec.ts
@@ -1,0 +1,47 @@
+import { readProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import generator from './cypress.impl';
+
+describe('Cypress generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should generate cypress project', async () => {
+    await generator(tree, { project: 'demo', name: 'demo-e2e' });
+
+    const config = readProjectConfiguration(tree, 'demo-e2e');
+    expect(config.targets).toEqual({
+      e2e: {
+        dependsOn: ['dev-server'],
+        executor: '@nx/cypress:cypress',
+        options: {
+          baseUrl: 'http://localhost:3000',
+          cypressConfig: 'demo-e2e/cypress.config.ts',
+          skipServe: true,
+          testingType: 'e2e',
+        },
+      },
+      lint: {
+        executor: '@nx/linter:eslint',
+        options: {
+          lintFilePatterns: ['demo-e2e/**/*.{js,ts}'],
+        },
+        outputs: ['{options.outputFile}'],
+      },
+      'dev-server': {
+        command: 'nx serve demo',
+        configurations: {
+          production: {
+            command: 'nx serve demo --configuration=production',
+          },
+        },
+        options: {
+          readyWhen: 'Server started',
+        },
+      },
+    });
+  });
+});

--- a/packages/remix/src/generators/cypress/schema.d.ts
+++ b/packages/remix/src/generators/cypress/schema.d.ts
@@ -1,0 +1,10 @@
+export interface CypressGeneratorSchema {
+  project: string;
+  name: string;
+  baseUrl?: string;
+  directory?: string;
+  linter?: 'none' | 'eslint';
+  js?: boolean;
+  skipFormat?: boolean;
+  setParserOptionsProject?: boolean;
+}


### PR DESCRIPTION
When generating the remix app, the e2e tests don't work unless the use pass in specific options. It is not a good experience for users.

The Cypress executor needs the executor in `devServerTarget` to emit a value (e.g. `{success: true, baseUrl: 'http://localhost:3000}`, but `run-commands` don't do this. Thus we need to start the dev server in another dependency task, and pass `skipServe` to Cypress.