### PR TITLE
feat(remix): add a serve executor

### DIFF
--- a/packages/remix/executors.json
+++ b/packages/remix/executors.json
@@ -1,5 +1,10 @@
 {
   "executors": {
+    "serve": {
+      "implementation": "./src/executors/serve/serve.impl",
+      "schema": "./src/executors/serve/schema.json",
+      "description": "Serve a Remix application."
+    },
     "build": {
       "implementation": "./src/executors/build/build.impl",
       "schema": "./src/executors/build/schema.json",
@@ -7,8 +12,13 @@
     }
   },
   "builders": {
+    "serve": {
+      "implementation": "./src/executors/serve/compat",
+      "schema": "./src/executors/serve/schema.json",
+      "description": "Serve a Remix application."
+    },
     "build": {
-      "implementation": "./src/executors/build/compat",
+      "implementation": "./src/executors/build/build.impl",
       "schema": "./src/executors/build/schema.json",
       "description": "Build a Remix application."
     }

--- a/packages/remix/src/executors/serve/compat.ts
+++ b/packages/remix/src/executors/serve/compat.ts
@@ -1,0 +1,5 @@
+import { convertNxExecutor } from '@nx/devkit';
+
+import serveExecutor from './serve.impl';
+
+export default convertNxExecutor(serveExecutor);

--- a/packages/remix/src/executors/serve/schema.d.ts
+++ b/packages/remix/src/executors/serve/schema.d.ts
@@ -1,0 +1,9 @@
+export interface RemixServeSchema {
+  port: number;
+  devServerPort?: number;
+  debug?: boolean;
+  command?: string;
+  manual?: boolean;
+  tlsKey?: string;
+  tlsCert?: string;
+}

--- a/packages/remix/src/executors/serve/schema.json
+++ b/packages/remix/src/executors/serve/schema.json
@@ -1,0 +1,41 @@
+{
+  "version": 2,
+  "outputCapture": "pipe",
+  "cli": "nx",
+  "title": "Remix Serve",
+  "description": "Serve a Remix app.",
+  "type": "object",
+  "properties": {
+    "port": {
+      "type": "number",
+      "description": "Set PORT environment variable that can be used to serve the Remix application.",
+      "default": 4200
+    },
+    "devServerPort": {
+      "type": "number",
+      "description": "Port to start the dev server on."
+    },
+    "debug": {
+      "type": "boolean",
+      "description": "Attach a Node.js inspector.",
+      "default": false
+    },
+    "command": {
+      "type": "string",
+      "description": "Command used to run your app server."
+    },
+    "manual": {
+      "type": "boolean",
+      "description": "Enable manual mode",
+      "default": false
+    },
+    "tlsKey": {
+      "type": "string",
+      "description": "Path to TLS key (key.pem)."
+    },
+    "tlsCert": {
+      "type": "string",
+      "description": "Path to TLS certificate (cert.pem)."
+    }
+  }
+}

--- a/packages/remix/src/executors/serve/serve.impl.ts
+++ b/packages/remix/src/executors/serve/serve.impl.ts
@@ -1,0 +1,95 @@
+import { workspaceRoot, type ExecutorContext } from '@nx/devkit';
+import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
+import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import { fork } from 'node:child_process';
+import { join } from 'node:path';
+import { type RemixServeSchema } from './schema';
+
+function normalizeOptions(schema: RemixServeSchema) {
+  return {
+    ...schema,
+    port: schema.port ?? 4200,
+    debug: schema.debug ?? false,
+    manual: schema.manual ?? false,
+  } as RemixServeSchema;
+}
+
+function buildRemixDevArgs(options: RemixServeSchema) {
+  const args = [];
+
+  if (options.command) {
+    args.push(`--command=${options.command}`);
+  }
+
+  if (options.devServerPort) {
+    args.push(`--port=${options.devServerPort}`);
+  }
+
+  if (options.debug) {
+    args.push(`--debug`);
+  }
+
+  if (options.manual) {
+    args.push(`--manual`);
+  }
+
+  if (options.tlsKey) {
+    args.push(`--tls-key=${options.tlsKey}`);
+  }
+
+  if (options.tlsCert) {
+    args.push(`--tls-cert=${options.tlsCert}`);
+  }
+
+  return args;
+}
+
+export default async function* serveExecutor(
+  schema: RemixServeSchema,
+  context: ExecutorContext
+) {
+  const options = normalizeOptions(schema);
+  const projectRoot = context.workspace.projects[context.projectName].root;
+
+  const remixBin = require.resolve('@remix-run/dev/dist/cli');
+  const args = buildRemixDevArgs(options);
+  // Cast to any to overwrite NODE_ENV
+  (process.env as any).NODE_ENV = process.env.NODE_ENV
+    ? process.env.NODE_ENV
+    : 'development';
+  process.env.PORT = `${options.port}`;
+
+  yield* createAsyncIterable<{ success: boolean; baseUrl: string }>(
+    async ({ done, next, error }) => {
+      const server = fork(remixBin, ['dev', ...args], {
+        cwd: join(workspaceRoot, projectRoot),
+        stdio: 'inherit',
+      });
+
+      server.once('exit', (code) => {
+        if (code === 0) {
+          done();
+        } else {
+          error(new Error(`Remix app exited with code ${code}`));
+        }
+      });
+
+      const killServer = () => {
+        if (server.connected) {
+          server.kill('SIGTERM');
+        }
+      };
+      process.on('exit', () => killServer());
+      process.on('SIGINT', () => killServer());
+      process.on('SIGTERM', () => killServer());
+      process.on('SIGHUP', () => killServer());
+
+      await waitForPortOpen(options.port);
+
+      next({
+        success: true,
+        baseUrl: `http://localhost:${options.port}`,
+      });
+    }
+  );
+}

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -314,8 +314,8 @@ function expectTargetsToBeCorrect(tree: Tree, projectRoot: string) {
     joinPathFragments('dist', projectRoot)
   );
   expect(targets.serve).toBeTruthy();
-  expect(targets.serve.command).toEqual('remix dev');
-  expect(targets.serve.options.cwd).toEqual(projectRoot);
+  expect(targets.serve.executor).toEqual('@nx/remix:serve');
+  expect(targets.serve.options.port).toEqual(4200);
   expect(targets.start).toBeTruthy();
   expect(targets.start.command).toEqual('remix-serve build');
   expect(targets.start.options.cwd).toEqual(projectRoot);

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -47,9 +47,9 @@ export default async function (tree: Tree, _options: NxRemixGeneratorSchema) {
         },
       },
       serve: {
-        command: `remix dev`,
+        executor: `@nx/remix:serve`,
         options: {
-          cwd: options.projectRoot,
+          port: 4200,
         },
       },
       start: {


### PR DESCRIPTION

Add a Remix Serve Executor to allow emissions from the process that can be listened to by other processes such as Cypress.
