### PR TITLE
fix(deno): provide proper error handling for process-graph

### DIFF
--- a/packages/deno/src/graph/process-graph.ts
+++ b/packages/deno/src/graph/process-graph.ts
@@ -151,7 +151,7 @@ async function getDenoFileInfo(fileToProcess: FileData) {
     ],
     { stdio: 'pipe' }
   );
-  return await new Promise((res) => {
+  return await new Promise((resolve, reject) => {
     let buffer = '';
 
     denoInfo.stdout.on('data', (chunk) => {
@@ -159,7 +159,11 @@ async function getDenoFileInfo(fileToProcess: FileData) {
     });
 
     denoInfo.on('close', () => {
-      res(JSON.parse(buffer));
+      try {
+        resolve(JSON.parse(buffer));
+      } catch (err) {
+        reject(err)
+      }
     });
   });
 }


### PR DESCRIPTION
# Motivation

Within `getDenoFileInfo`, in situations where `deno info` fails it won't provide a proper JSON output, causing `buffer` to remain as an empty string and `JSON.parse(buffer)` to fail by consequence. The problem is that the current implementation wont' handle this error properly, making it generic and harder to debug.

Adding a `try ... catch` block that delegates the error object to the promise's `reject` handler ensures that this error is encapsulate into a `DenoError` object.

# Then

```sh
npx nx serve api

 >  NX   Daemon process terminated and closed the connection

   Please rerun the command, which will restart the daemon.
   If you get this error again, check for any errors in the daemon process logs found in: /Users/.../node_modules/.cache/nx/d/daemon.log
```

<img width="681" alt="image" src="https://github.com/nrwl/nx-labs/assets/1886960/0d14b210-f475-47e2-aa1f-bd9b3e75d4ef">

## `daemon.log`

```
[NX Daemon Server] - 2023-07-31T16:28:38.990Z - Started listening on: /var/folders/0w/r3cdyt0n4cs3553956xtnysc0000gn/T/19ae6823815c828ba9b4/d.sock
[NX Daemon Server] - 2023-07-31T16:28:38.991Z - [WATCHER]: Subscribed to changes within: /Users/john.doe/project (native)
[NX Daemon Server] - 2023-07-31T16:28:38.995Z - Established a connection. Number of open connections: 1
[NX Daemon Server] - 2023-07-31T16:28:38.996Z - Established a connection. Number of open connections: 2
[NX Daemon Server] - 2023-07-31T16:28:38.997Z - Closed a connection. Number of open connections: 1
[NX Daemon Server] - 2023-07-31T16:28:38.997Z - [REQUEST]: Client Request for Project Graph Received
fatal: no path specified
[NX Daemon Server] - 2023-07-31T16:28:39.081Z - [REQUEST]: Updated file-hasher based on watched changes, recomputing project graph...
[NX Daemon Server] - 2023-07-31T16:28:39.081Z - [REQUEST]: 
[NX Daemon Server] - 2023-07-31T16:28:39.081Z - [REQUEST]: 
[NX Daemon Server] - 2023-07-31T16:28:39.572Z - Time taken for 'hash changed files from watcher' 19.836166977882385ms
[NX Daemon Server] - 2023-07-31T16:28:40.005Z - Error detected when creating a project graph: Failed to process the project graph with "@nx/deno".
[NX Daemon Server] - 2023-07-31T16:28:40.005Z - [REQUEST]: Responding to the client with an error. Error when preparing serialized project graph. Failed to process the project graph with "@nx/deno".
DenoError: Failed to process the project graph with "@nx/deno".
    at /Users/john.doe/project/node_modules/.pnpm/@nx+deno@16.4.0_nx@16.5.5_typescript@5.1.6/node_modules/@nx/deno/src/graph/process-graph.js:75:19 {
  innerError: SyntaxError: Unexpected end of JSON input
      at JSON.parse (<anonymous>)
      at ChildProcess.<anonymous> (/Users/john.doe/project/node_modules/.pnpm/@nx+deno@16.4.0_nx@16.5.5_typescript@5.1.6/node_modules/@nx/deno/src/graph/process-graph.js:110:26)
      at ChildProcess.emit (node:events:512:28)
      at maybeClose (node:internal/child_process:1098:16)
      at Socket.<anonymous> (node:internal/child_process:456:11)
      at Socket.emit (node:events:512:28)
      at Pipe.<anonymous> (node:net:334:12)
}
```

# Now

<img width="823" alt="image" src="https://github.com/nrwl/nx-labs/assets/1886960/94e47a2c-99ab-44f2-8d31-287d86cd10d4">
