### PR TITLE
chore(nx-ignore): git config for e2e tests

### DIFF
--- a/e2e/nx-ignore-e2e/tests/nx-ignore.spec.ts
+++ b/e2e/nx-ignore-e2e/tests/nx-ignore.spec.ts
@@ -32,6 +32,8 @@ describe('nx-ignore e2e', () => {
       )
     );
     runCommand(`git init`, {});
+    runCommand(`git config user.email "you@example.com"`, {});
+    runCommand(`git config user.name "Your Name"`, {});
     runCommand(`git add .`, {});
     runCommand(`git commit -m 'init'`, {});
   });


### PR DESCRIPTION
Configure commit for e2e tests, because if it's not configured then it may fail on CI with following error message:

```
 Committer identity unknown
      
      *** Please tell me who you are.
      
      Run
      
        git config --global user.email "you@example.com"
        git config --global user.name "Your Name"
```