### PR TITLE
chore: don't use rspack internal module

### DIFF
--- a/packages/rspack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/rspack/src/executors/dev-server/dev-server.impl.ts
@@ -4,12 +4,12 @@ import {
   readTargetOptions,
 } from '@nx/devkit';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
-import { DevServer } from '@rspack/core/dist/config';
+import { Configuration } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
 import { createCompiler } from '../../utils/create-compiler';
 import { isMode } from '../../utils/mode-utils';
 import { DevServerExecutorSchema } from './schema';
-
+type DevServer = Configuration['devServer'];
 export default async function* runExecutor(
   options: DevServerExecutorSchema,
   context: ExecutorContext

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -1,7 +1,6 @@
 import { ExecutorContext, logger } from '@nx/devkit';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
 import { Stats } from '@rspack/core';
-import Watching from '@rspack/core/dist/watching';
 import { rmSync } from 'fs';
 import * as path from 'path';
 import { createCompiler } from '../../utils/create-compiler';
@@ -30,7 +29,7 @@ export default async function* runExecutor(
     outfile?: string;
   }>(async ({ next, done }) => {
     if (options.watch) {
-      const watcher: Watching = compiler.watch(
+      const watcher= compiler.watch(
         {},
         async (err, stats: Stats) => {
           if (err) {


### PR DESCRIPTION
Rspack's internal module is not exposed since 0.3, so it would be better not use Rspack's internal module