### PR TITLE
fix(remix): run Remix CLI instead of invoking the build programmatically

### DIFF
--- a/packages/remix/src/executors/build/schema.d.ts
+++ b/packages/remix/src/executors/build/schema.d.ts
@@ -1,5 +1,7 @@
 export interface RemixBuildSchema {
   outputPath: string;
-  includeDevDependenciesInPackageJson: boolean;
-  generateLockfile: boolean;
+  includeDevDependenciesInPackageJson?: boolean;
+  generatePackageJson?: boolean;
+  generateLockfile?: boolean;
+  sourcemap?: boolean;
 }

--- a/packages/remix/src/executors/build/schema.json
+++ b/packages/remix/src/executors/build/schema.json
@@ -18,14 +18,21 @@
       "description": "Include `devDependencies` in the generated package.json file. By default only production `dependencies` are included.",
       "default": false
     },
+    "generatePackageJson": {
+      "type": "boolean",
+      "description": "Generate package.json file in the output folder.",
+      "default": false
+    },
     "generateLockfile": {
       "type": "boolean",
       "description": "Generate a lockfile (e.g. package-lock.json) that matches the workspace lockfile to ensure package versions match.",
-      "default": false,
-      "x-priority": "internal"
+      "default": false
+    },
+    "sourcemap": {
+      "type": "boolean",
+      "description": "Generate source maps for production.",
+      "default": false
     }
   },
-  "required": [
-    "outputPath"
-  ]
+  "required": ["outputPath"]
 }


### PR DESCRIPTION
This PR fixes the Remix `build` executor to be consistent with `serve` executor -- invoking the CLI using `fork`. This change resolves and issue where postcss and other tools are using the wrong `cwd` when looking for configuration files. Tested on the `ocean` repo.