### PR TITLE
chore(repo): use node 18 for GH Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,7 +28,7 @@ jobs:
           deno-version: '^1.3'
       - uses: actions/setup-node@v1
         with:
-          node-version: '16'
+          node-version: '18'
       - run: yarn
       - run: deno info && deno --version
       - run: npx nx affected --target=lint --parallel --max-parallel=3
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        agent: [1, 2, 3]
+        agent: [ 1, 2, 3 ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Use Node 18 in GH Actions for the nx-labs repo.

This helps prepare the repo for Remix v2
