### PR TITLE
feat(remix): implement new projectNameAndRootFormat for application

### DIFF
--- a/e2e/remix-e2e/tests/nx-remix.spec.ts
+++ b/e2e/remix-e2e/tests/nx-remix.spec.ts
@@ -55,18 +55,30 @@ describe('remix e2e', () => {
   }, 120000);
 
   describe('--directory', () => {
-    it('should create src in the specified directory', async () => {
+    it('should create src in the specified directory --projectNameAndRootFormat=derived', async () => {
       const plugin = uniq('remix');
-      const appName = `subdir-${plugin}`;
+      const appName = `sub-${plugin}`;
       await runNxCommandAsync(
-        `generate @nx/remix:app ${plugin} --directory subdir --rootProject=false`
+        `generate @nx/remix:app ${plugin} --directory=sub --projectNameAndRootFormat=derived --rootProject=false`
       );
-      const project = readJson(`subdir/${plugin}/project.json`);
+      const project = readJson(`sub/${plugin}/project.json`);
       expect(project.targets.build.options.outputPath).toEqual(
-        `dist/subdir/${plugin}`
+        `dist/sub/${plugin}`
       );
 
       const result = await runNxCommandAsync(`build ${appName}`);
+      expect(result.stdout).toContain('Successfully ran target build');
+    }, 120000);
+
+    it('should create src in the specified directory --projectNameAndRootFormat=as-provided', async () => {
+      const plugin = uniq('remix');
+      await runNxCommandAsync(
+        `generate @nx/remix:app ${plugin} --directory=subdir --projectNameAndRootFormat=as-provided --rootProject=false`
+      );
+      const project = readJson(`subdir/project.json`);
+      expect(project.targets.build.options.outputPath).toEqual(`dist/subdir`);
+
+      const result = await runNxCommandAsync(`build ${plugin}`);
       expect(result.stdout).toContain('Successfully ran target build');
     }, 120000);
   });

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Remix Application Integrated Repo --directory should create the application correctly 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --directory should create the application correctly 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -15,7 +15,7 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo --directory should create the application correctly 2`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --directory should create the application correctly 2`] = `
 "import type { MetaFunction } from '@remix-run/node';
 import {
   Links,
@@ -51,7 +51,7 @@ export default function App() {
 "
 `;
 
-exports[`Remix Application Integrated Repo --directory should create the application correctly 3`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --directory should create the application correctly 3`] = `
 "export default function Index() {
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
@@ -87,7 +87,7 @@ exports[`Remix Application Integrated Repo --directory should create the applica
 "
 `;
 
-exports[`Remix Application Integrated Repo --directory should extract the layout directory from the directory options if it exists 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --directory should extract the layout directory from the directory options if it exists 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -102,7 +102,7 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo --directory should extract the layout directory from the directory options if it exists 2`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --directory should extract the layout directory from the directory options if it exists 2`] = `
 "import type { MetaFunction } from '@remix-run/node';
 import {
   Links,
@@ -138,7 +138,7 @@ export default function App() {
 "
 `;
 
-exports[`Remix Application Integrated Repo --directory should extract the layout directory from the directory options if it exists 3`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --directory should extract the layout directory from the directory options if it exists 3`] = `
 "export default function Index() {
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
@@ -174,7 +174,7 @@ exports[`Remix Application Integrated Repo --directory should extract the layout
 "
 `;
 
-exports[`Remix Application Integrated Repo --js should create the application correctly 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --js should create the application correctly 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -189,7 +189,7 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo --js should create the application correctly 2`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --js should create the application correctly 2`] = `
 "import {
   Links,
   LiveReload,
@@ -222,7 +222,7 @@ export default function App() {
 "
 `;
 
-exports[`Remix Application Integrated Repo --js should create the application correctly 3`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --js should create the application correctly 3`] = `
 "export default function Index() {
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
@@ -258,7 +258,7 @@ exports[`Remix Application Integrated Repo --js should create the application co
 "
 `;
 
-exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using jest 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --unitTestRunner should generate the correct files for testing using jest 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -273,22 +273,22 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using jest 2`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --unitTestRunner should generate the correct files for testing using jest 2`] = `
 "/* eslint-disable */
 export default {
   setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
   displayName: 'test',
-  preset: '../../jest.preset.js',
+  preset: '../jest.preset.js',
   transform: {
     '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-  coverageDirectory: '../../coverage/apps/test',
+  coverageDirectory: '../coverage/test',
 };
 "
 `;
 
-exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using vitest 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --unitTestRunner should generate the correct files for testing using vitest 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -303,14 +303,14 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using vitest 2`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided --unitTestRunner should generate the correct files for testing using vitest 2`] = `
 "/// <reference types='vitest' />
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  cacheDir: '../../node_modules/.vite/test',
+  cacheDir: '../node_modules/.vite/test',
 
   plugins: [react(), nxViteTsPaths()],
 
@@ -323,7 +323,7 @@ export default defineConfig({
     setupFiles: ['./test-setup.ts'],
     globals: true,
     cache: {
-      dir: '../../node_modules/.vitest',
+      dir: '../node_modules/.vitest',
     },
     environment: 'jsdom',
     include: ['./app/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
@@ -332,7 +332,7 @@ export default defineConfig({
 "
 `;
 
-exports[`Remix Application Integrated Repo should create the application correctly 1`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided should create the application correctly 1`] = `
 "/**
  * @type {import('@remix-run/dev').AppConfig}
  */
@@ -347,7 +347,7 @@ module.exports = {
 "
 `;
 
-exports[`Remix Application Integrated Repo should create the application correctly 2`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided should create the application correctly 2`] = `
 "import type { MetaFunction } from '@remix-run/node';
 import {
   Links,
@@ -383,7 +383,426 @@ export default function App() {
 "
 `;
 
-exports[`Remix Application Integrated Repo should create the application correctly 3`] = `
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=as-provided should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --directory should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --directory should create the application correctly 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --directory should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --directory should extract the layout directory from the directory options if it exists 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --directory should extract the layout directory from the directory options if it exists 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --directory should extract the layout directory from the directory options if it exists 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --js should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --js should create the application correctly 2`] = `
+"import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+export const meta = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --js should create the application correctly 3`] = `
+"export default function Index() {
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>
+      <h1>Welcome to Remix</h1>
+      <ul>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/blog\\"
+            rel=\\"noreferrer\\"
+          >
+            15m Quickstart Blog Tutorial
+          </a>
+        </li>
+        <li>
+          <a
+            target=\\"_blank\\"
+            href=\\"https://remix.run/tutorials/jokes\\"
+            rel=\\"noreferrer\\"
+          >
+            Deep Dive Jokes App Tutorial
+          </a>
+        </li>
+        <li>
+          <a target=\\"_blank\\" href=\\"https://remix.run/docs\\" rel=\\"noreferrer\\">
+            Remix Docs
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --unitTestRunner should generate the correct files for testing using jest 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --unitTestRunner should generate the correct files for testing using jest 2`] = `
+"/* eslint-disable */
+export default {
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+  displayName: 'test',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\\\\\\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/apps/test',
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --unitTestRunner should generate the correct files for testing using vitest 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived --unitTestRunner should generate the correct files for testing using vitest 2`] = `
+"/// <reference types='vitest' />
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/test',
+
+  plugins: [react(), nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    setupFiles: ['./test-setup.ts'],
+    globals: true,
+    cache: {
+      dir: '../../node_modules/.vitest',
+    },
+    environment: 'jsdom',
+    include: ['./app/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived should create the application correctly 1`] = `
+"/**
+ * @type {import('@remix-run/dev').AppConfig}
+ */
+module.exports = {
+  ignoredRouteFiles: ['**/.*'],
+  // appDirectory: \\"app\\",
+  // assetsBuildDirectory: \\"public/build\\",
+  // serverBuildPath: \\"build/index.js\\",
+  // publicPath: \\"/build/\\",
+  watchPaths: () => require('@nx/remix').createWatchPaths(__dirname),
+};
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived should create the application correctly 2`] = `
+"import type { MetaFunction } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from '@remix-run/react';
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
+
+export default function App() {
+  return (
+    <html lang=\\"en\\">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+"
+`;
+
+exports[`Remix Application Integrated Repo --projectNameAndRootFormat=derived should create the application correctly 3`] = `
 "export default function Index() {
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', lineHeight: '1.4' }}>

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { joinPathFragments, readJson } from '@nx/devkit';
+import { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import applicationGenerator from './application.impl';
 
@@ -115,7 +116,7 @@ describe('Remix Application', () => {
           import { defineConfig } from 'cypress';
 
           export default defineConfig({
-            e2e: nxE2EPreset(__dirname),
+            e2e: nxE2EPreset(__filename, { cypressDir: 'src' }),
           });
           "
         `);
@@ -123,27 +124,12 @@ describe('Remix Application', () => {
     });
   });
 
-  describe('Integrated Repo', () => {
-    it('should create the application correctly', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-      // ACT
-      await applicationGenerator(tree, {
-        name: 'test',
-      });
-
-      // ASSERT
-      expectTargetsToBeCorrect(tree, 'apps/test');
-
-      expect(tree.read('apps/test/remix.config.js', 'utf-8')).toMatchSnapshot();
-      expect(tree.read('apps/test/app/root.tsx', 'utf-8')).toMatchSnapshot();
-      expect(
-        tree.read('apps/test/app/routes/index.tsx', 'utf-8')
-      ).toMatchSnapshot();
-    });
-
-    describe('--js', () => {
+  describe.each([
+    ['derived', 'apps/test', 'apps/test-e2e'],
+    ['as-provided', 'test', 'test-e2e'],
+  ])(
+    'Integrated Repo --projectNameAndRootFormat=%s',
+    (projectNameAndRootFormat: ProjectNameAndRootFormat, appDir, e2eDir) => {
       it('should create the application correctly', async () => {
         // ARRANGE
         const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
@@ -151,156 +137,194 @@ describe('Remix Application', () => {
         // ACT
         await applicationGenerator(tree, {
           name: 'test',
-          js: true,
+          projectNameAndRootFormat,
         });
 
         // ASSERT
-        expectTargetsToBeCorrect(tree, 'apps/test');
+        expectTargetsToBeCorrect(tree, appDir);
 
         expect(
-          tree.read('apps/test/remix.config.js', 'utf-8')
+          tree.read(`${appDir}/remix.config.js`, 'utf-8')
         ).toMatchSnapshot();
-        expect(tree.read('apps/test/app/root.js', 'utf-8')).toMatchSnapshot();
+        expect(tree.read(`${appDir}/app/root.tsx`, 'utf-8')).toMatchSnapshot();
         expect(
-          tree.read('apps/test/app/routes/index.js', 'utf-8')
-        ).toMatchSnapshot();
-      });
-    });
-    describe('--directory', () => {
-      it('should create the application correctly', async () => {
-        // ARRANGE
-        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-        // ACT
-        await applicationGenerator(tree, {
-          name: 'test',
-          directory: 'demo',
-        });
-
-        // ASSERT
-        expectTargetsToBeCorrect(tree, 'apps/demo/test');
-
-        expect(
-          tree.read('apps/demo/test/remix.config.js', 'utf-8')
-        ).toMatchSnapshot();
-        expect(
-          tree.read('apps/demo/test/app/root.tsx', 'utf-8')
-        ).toMatchSnapshot();
-        expect(
-          tree.read('apps/demo/test/app/routes/index.tsx', 'utf-8')
+          tree.read(`${appDir}/app/routes/index.tsx`, 'utf-8')
         ).toMatchSnapshot();
       });
 
-      it('should extract the layout directory from the directory options if it exists', async () => {
-        // ARRANGE
-        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      describe('--js', () => {
+        it('should create the application correctly', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-        // ACT
-        await applicationGenerator(tree, {
-          name: 'test',
-          directory: 'apps/demo',
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            js: true,
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expectTargetsToBeCorrect(tree, appDir);
+
+          expect(
+            tree.read(`${appDir}/remix.config.js`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(tree.read(`${appDir}/app/root.js`, 'utf-8')).toMatchSnapshot();
+          expect(
+            tree.read(`${appDir}/app/routes/index.js`, 'utf-8')
+          ).toMatchSnapshot();
         });
-
-        // ASSERT
-        expectTargetsToBeCorrect(tree, 'apps/demo/test');
-
-        expect(
-          tree.read('apps/demo/test/remix.config.js', 'utf-8')
-        ).toMatchSnapshot();
-        expect(
-          tree.read('apps/demo/test/app/root.tsx', 'utf-8')
-        ).toMatchSnapshot();
-        expect(
-          tree.read('apps/demo/test/app/routes/index.tsx', 'utf-8')
-        ).toMatchSnapshot();
       });
-    });
+      describe('--directory', () => {
+        it('should create the application correctly', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+          const newAppDir =
+            projectNameAndRootFormat === 'as-provided'
+              ? 'demo'
+              : 'apps/demo/test';
 
-    describe('--unitTestRunner', () => {
-      it('should generate the correct files for testing using vitest', async () => {
-        // ARRANGE
-        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            directory: 'demo',
+            projectNameAndRootFormat,
+          });
 
-        // ACT
-        await applicationGenerator(tree, {
-          name: 'test',
-          unitTestRunner: 'vitest',
+          // ASSERT
+          expectTargetsToBeCorrect(tree, newAppDir);
+
+          expect(
+            tree.read(`${newAppDir}/remix.config.js`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${newAppDir}/app/root.tsx`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${newAppDir}/app/routes/index.tsx`, 'utf-8')
+          ).toMatchSnapshot();
         });
 
-        // ASSERT
-        expectTargetsToBeCorrect(tree, 'apps/test');
+        it('should extract the layout directory from the directory options if it exists', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+          const newAppDir =
+            projectNameAndRootFormat === 'as-provided'
+              ? 'apps/demo'
+              : 'apps/demo/test';
 
-        expect(
-          tree.read('apps/test/remix.config.js', 'utf-8')
-        ).toMatchSnapshot();
-        expect(
-          tree.read('apps/test/vite.config.ts', 'utf-8')
-        ).toMatchSnapshot();
-        expect(tree.read('apps/test/test-setup.ts', 'utf-8'))
-          .toMatchInlineSnapshot(`
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            directory: 'apps/demo',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expectTargetsToBeCorrect(tree, newAppDir);
+
+          expect(
+            tree.read(`${newAppDir}/remix.config.js`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${newAppDir}/app/root.tsx`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${newAppDir}/app/routes/index.tsx`, 'utf-8')
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('--unitTestRunner', () => {
+        it('should generate the correct files for testing using vitest', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            unitTestRunner: 'vitest',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expectTargetsToBeCorrect(tree, appDir);
+
+          expect(
+            tree.read(`${appDir}/remix.config.js`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${appDir}/vite.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(tree.read(`${appDir}/test-setup.ts`, 'utf-8'))
+            .toMatchInlineSnapshot(`
           "import { installGlobals } from '@remix-run/node';
           import '@testing-library/jest-dom/extend-expect';
           installGlobals();
           "
         `);
-      });
-
-      it('should generate the correct files for testing using jest', async () => {
-        // ARRANGE
-        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-        // ACT
-        await applicationGenerator(tree, {
-          name: 'test',
-          unitTestRunner: 'jest',
         });
 
-        // ASSERT
-        expectTargetsToBeCorrect(tree, 'apps/test');
+        it('should generate the correct files for testing using jest', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-        expect(
-          tree.read('apps/test/remix.config.js', 'utf-8')
-        ).toMatchSnapshot();
-        expect(
-          tree.read('apps/test/jest.config.ts', 'utf-8')
-        ).toMatchSnapshot();
-        expect(tree.read('apps/test/test-setup.ts', 'utf-8'))
-          .toMatchInlineSnapshot(`
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            unitTestRunner: 'jest',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expectTargetsToBeCorrect(tree, appDir);
+
+          expect(
+            tree.read(`${appDir}/remix.config.js`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(
+            tree.read(`${appDir}/jest.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(tree.read(`${appDir}/test-setup.ts`, 'utf-8'))
+            .toMatchInlineSnapshot(`
           "import { installGlobals } from '@remix-run/node';
           import '@testing-library/jest-dom/extend-expect';
           installGlobals();
           "
         `);
-      });
-    });
-
-    describe('--e2eTestRunner', () => {
-      it('should generate an e2e application for the app', async () => {
-        // ARRANGE
-        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-        // ACT
-        await applicationGenerator(tree, {
-          name: 'test',
-          e2eTestRunner: 'cypress',
         });
+      });
 
-        // ASSERT
-        expectTargetsToBeCorrect(tree, 'apps/test');
+      describe('--e2eTestRunner', () => {
+        it('should generate an e2e application for the app', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-        expect(tree.read('apps/test-e2e/cypress.config.ts', 'utf-8'))
-          .toMatchInlineSnapshot(`
+          // ACT
+          await applicationGenerator(tree, {
+            name: 'test',
+            e2eTestRunner: 'cypress',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expectTargetsToBeCorrect(tree, appDir);
+
+          expect(tree.read(`${appDir}-e2e/cypress.config.ts`, 'utf-8'))
+            .toMatchInlineSnapshot(`
           "import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
           import { defineConfig } from 'cypress';
 
           export default defineConfig({
-            e2e: nxE2EPreset(__dirname),
+            e2e: nxE2EPreset(__filename, { cypressDir: 'src' }),
           });
           "
         `);
+        });
       });
-    });
-  });
+    }
+  );
 });
 
 function expectTargetsToBeCorrect(tree: Tree, projectRoot: string) {

--- a/packages/remix/src/generators/application/schema.d.ts
+++ b/packages/remix/src/generators/application/schema.d.ts
@@ -1,8 +1,11 @@
+import { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
+
 export interface NxRemixGeneratorSchema {
   name: string;
   tags?: string;
   js?: boolean;
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   unitTestRunner?: 'vitest' | 'jest' | 'none';
   e2eTestRunner?: 'cypress' | 'none';
   skipFormat?: boolean;

--- a/packages/remix/src/generators/application/schema.json
+++ b/packages/remix/src/generators/application/schema.json
@@ -24,6 +24,14 @@
       "alias": "dir",
       "x-priority": "important"
     },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
+    },
     "unitTestRunner": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
Bring Remix Appliction Generator in line with the rest of the Nx Official Plugins by implementing the new `projectNameAndRootFormat` option.

