### PR TITLE
feat(remix): projectNameAndRootFormat for library generator

### DIFF
--- a/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
+++ b/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Remix Library Generator -projectNameAndRootFormat=as-provided --unitTestRunner should create the correct config files for testing with jest 1`] = `
+"/* eslint-disable */
+export default {
+  setupFilesAfterEnv: ['./src/test-setup.ts'],
+  displayName: 'test',
+  preset: '../jest.preset.js',
+  transform: {
+    '^(?!.*\\\\\\\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\\\\\\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../coverage/test',
+};
+"
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=as-provided --unitTestRunner should create the correct config files for testing with vitest 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  cacheDir: '../node_modules/.vite/test',
+
+  plugins: [react(), nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    setupFiles: ['./src/test-setup.ts'],
+    globals: true,
+    cache: { dir: '../node_modules/.vitest' },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});
+"
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=as-provided should generate a library correctly 1`] = `
+Array [
+  "test.module.css",
+  "test.spec.tsx",
+  "test.tsx",
+]
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=as-provided should generate a library correctly 2`] = `
+Object {
+  "@proj/test": Array [
+    "test/src/index.ts",
+  ],
+  "@proj/test/server": Array [
+    "test/src/server.ts",
+  ],
+}
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=derived --unitTestRunner should create the correct config files for testing with jest 1`] = `
+"/* eslint-disable */
+export default {
+  setupFilesAfterEnv: ['./src/test-setup.ts'],
+  displayName: 'test',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^(?!.*\\\\\\\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\\\\\\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/test',
+};
+"
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=derived --unitTestRunner should create the correct config files for testing with vitest 1`] = `
+"import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/test',
+
+  plugins: [react(), nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    setupFiles: ['./src/test-setup.ts'],
+    globals: true,
+    cache: { dir: '../../node_modules/.vitest' },
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});
+"
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=derived should generate a library correctly 1`] = `
+Array [
+  "test.module.css",
+  "test.spec.tsx",
+  "test.tsx",
+]
+`;
+
+exports[`Remix Library Generator -projectNameAndRootFormat=derived should generate a library correctly 2`] = `
+Object {
+  "@proj/libs/test": Array [
+    "libs/test/src/index.ts",
+  ],
+  "@proj/libs/test/server": Array [
+    "libs/test/src/server.ts",
+  ],
+}
+`;

--- a/packages/remix/src/generators/library/lib/add-unit-testing.ts
+++ b/packages/remix/src/generators/library/lib/add-unit-testing.ts
@@ -1,7 +1,6 @@
 import {
   addDependenciesToPackageJson,
   joinPathFragments,
-  readProjectConfiguration,
   stripIndents,
   type Tree,
 } from '@nx/devkit';
@@ -18,11 +17,10 @@ import {
 import type { RemixLibraryOptions } from './normalize-options';
 
 export function addUnitTestingSetup(tree: Tree, options: RemixLibraryOptions) {
-  const { root: projectRoot } = readProjectConfiguration(
-    tree,
-    options.projectName
+  const pathToTestSetup = joinPathFragments(
+    options.projectRoot,
+    'src/test-setup.ts'
   );
-  const pathToTestSetup = joinPathFragments(projectRoot, 'src/test-setup.ts');
   let testSetupFileContents = '';
 
   if (tree.exists(pathToTestSetup)) {
@@ -38,10 +36,16 @@ export function addUnitTestingSetup(tree: Tree, options: RemixLibraryOptions) {
   );
 
   if (options.unitTestRunner === 'vitest') {
-    const pathToVitestConfig = joinPathFragments(projectRoot, `vite.config.ts`);
+    const pathToVitestConfig = joinPathFragments(
+      options.projectRoot,
+      `vite.config.ts`
+    );
     updateViteTestSetup(tree, pathToVitestConfig, './src/test-setup.ts');
   } else if (options.unitTestRunner === 'jest') {
-    const pathToJestConfig = joinPathFragments(projectRoot, `jest.config.ts`);
+    const pathToJestConfig = joinPathFragments(
+      options.projectRoot,
+      `jest.config.ts`
+    );
     updateJestTestSetup(tree, pathToJestConfig, './src/test-setup.ts');
   }
 

--- a/packages/remix/src/generators/library/lib/normalize-options.ts
+++ b/packages/remix/src/generators/library/lib/normalize-options.ts
@@ -1,35 +1,33 @@
 import type { Tree } from '@nx/devkit';
-import { extractLayoutDirectory, names } from '@nx/devkit';
+import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { getImportPath } from '@nx/js/src/utils/get-import-path';
-import {
-  normalizeDirectory,
-  normalizeProjectName,
-} from '../../../utils/project';
 import type { NxRemixGeneratorSchema } from '../schema';
 
 export interface RemixLibraryOptions extends NxRemixGeneratorSchema {
   projectName: string;
+  projectRoot: string;
 }
 
-export function normalizeOptions(
+export async function normalizeOptions(
   tree: Tree,
   options: NxRemixGeneratorSchema
-): RemixLibraryOptions {
-  const name = names(options.name).fileName;
+): Promise<RemixLibraryOptions> {
+  const { projectName, projectRoot, projectNameAndRootFormat } =
+    await determineProjectNameAndRootOptions(tree, {
+      name: options.name,
+      projectType: 'library',
+      directory: options.directory,
+      projectNameAndRootFormat: options.projectNameAndRootFormat,
+      callingGenerator: '@nx/remix:library',
+    });
 
-  const { projectDirectory } = extractLayoutDirectory(options.directory);
-  const fullProjectDirectory = normalizeDirectory(name, projectDirectory);
-
-  const importPath =
-    options.importPath ?? getImportPath(tree, fullProjectDirectory);
-
-  const projectName = normalizeProjectName(name, projectDirectory);
+  const importPath = options.importPath ?? getImportPath(tree, projectRoot);
 
   return {
     ...options,
     unitTestRunner: options.unitTestRunner ?? 'vitest',
-    name,
     importPath,
     projectName,
+    projectRoot,
   };
 }

--- a/packages/remix/src/generators/library/library.impl.spec.ts
+++ b/packages/remix/src/generators/library/library.impl.spec.ts
@@ -1,186 +1,155 @@
 import { readJson, readProjectConfiguration } from '@nx/devkit';
+import { type ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import libraryGenerator from './library.impl';
 
 describe('Remix Library Generator', () => {
-  it('should generate a library correctly', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  describe.each([
+    ['derived', 'libs/test'],
+    ['as-provided', 'test'],
+  ])(
+    '-projectNameAndRootFormat=%s',
+    (projectNameAndRootFormat: ProjectNameAndRootFormat, libDir) => {
+      it('should generate a library correctly', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
 
-    // ACT
-    await libraryGenerator(tree, {
-      name: 'test',
-      style: 'css',
-    });
-
-    // ASSERT
-    const tsconfig = readJson(tree, 'tsconfig.base.json');
-    expect(tree.exists('libs/test/src/server.ts'));
-    expect(tree.children('libs/test/src/lib')).toMatchInlineSnapshot(`
-      Array [
-        "test.module.css",
-        "test.spec.tsx",
-        "test.tsx",
-      ]
-    `);
-    expect(tsconfig.compilerOptions.paths).toMatchInlineSnapshot(`
-      Object {
-        "@proj/test": Array [
-          "libs/test/src/index.ts",
-        ],
-        "@proj/test/server": Array [
-          "libs/test/src/server.ts",
-        ],
-      }
-    `);
-  }, 25_000);
-
-  describe('Standalone Project Repo', () => {
-    it('should update the tsconfig paths correctly', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace();
-      await applicationGenerator(tree, {
-        name: 'demo',
-        rootProject: true,
-      });
-      const originalBaseTsConfig = readJson(tree, 'tsconfig.json');
-
-      // ACT
-      await libraryGenerator(tree, { name: 'test', style: 'css' });
-
-      // ASSERT
-      const updatedBaseTsConfig = readJson(tree, 'tsconfig.base.json');
-      expect(Object.keys(originalBaseTsConfig.compilerOptions.paths)).toContain(
-        '~/*'
-      );
-      expect(Object.keys(updatedBaseTsConfig.compilerOptions.paths)).toContain(
-        '~/*'
-      );
-    });
-  });
-
-  describe('--unitTestRunner', () => {
-    it('should not create config files when unitTestRunner=none', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-      // ACT
-      await libraryGenerator(tree, {
-        name: 'test',
-        style: 'css',
-        unitTestRunner: 'none',
-      });
-
-      // ASSERT
-      expect(tree.exists(`libs/test/jest.config.ts`)).toBeFalsy();
-      expect(tree.exists(`libs/test/vite.config.ts`)).toBeFalsy();
-    });
-
-    it('should create the correct config files for testing with jest', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-      // ACT
-      await libraryGenerator(tree, {
-        name: 'test',
-        style: 'css',
-        unitTestRunner: 'jest',
-      });
-
-      // ASSERT
-      expect(tree.read('libs/test/jest.config.ts', 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        export default {
-          setupFilesAfterEnv: ['./src/test-setup.ts'],
-          displayName: 'test',
-          preset: '../../jest.preset.js',
-          transform: {
-            '^(?!.*\\\\\\\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
-            '^.+\\\\\\\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
-          },
-          moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-          coverageDirectory: '../../coverage/libs/test',
-        };
-        "
-      `);
-      expect(tree.read('libs/test/src/test-setup.ts', 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "import { installGlobals } from '@remix-run/node';
-        import '@testing-library/jest-dom/extend-expect';
-        installGlobals();
-        "
-      `);
-    });
-
-    it('should create the correct config files for testing with vitest', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
-
-      // ACT
-      await libraryGenerator(tree, {
-        name: 'test',
-        style: 'css',
-        unitTestRunner: 'vitest',
-      });
-
-      // ASSERT
-      expect(tree.read('libs/test/vite.config.ts', 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-        import react from '@vitejs/plugin-react';
-        import { defineConfig } from 'vite';
-
-        export default defineConfig({
-          cacheDir: '../../node_modules/.vite/test',
-
-          plugins: [react(), nxViteTsPaths()],
-
-          // Uncomment this if you are using workers.
-          // worker: {
-          //  plugins: [ nxViteTsPaths() ],
-          // },
-
-          test: {
-            setupFiles: ['./src/test-setup.ts'],
-            globals: true,
-            cache: { dir: '../../node_modules/.vitest' },
-            environment: 'jsdom',
-            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-          },
+        // ACT
+        await libraryGenerator(tree, {
+          name: 'test',
+          style: 'css',
+          projectNameAndRootFormat,
         });
-        "
-      `);
 
-      expect(tree.read('libs/test/src/test-setup.ts', 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "import { installGlobals } from '@remix-run/node';
-        import '@testing-library/jest-dom/extend-expect';
-        installGlobals();
-        "
-      `);
-    }, 25_000);
-  });
+        // ASSERT
+        const tsconfig = readJson(tree, 'tsconfig.base.json');
+        expect(tree.exists(`${libDir}/src/server.ts`));
+        expect(tree.children(`${libDir}/src/lib`)).toMatchSnapshot();
+        expect(tsconfig.compilerOptions.paths).toMatchSnapshot();
+      }, 25_000);
 
-  // TODO(Colum): Unskip this when buildable is investigated correctly
-  xit('should generate the config files correctly when the library is buildable', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      describe('Standalone Project Repo', () => {
+        it('should update the tsconfig paths correctly', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace();
+          await applicationGenerator(tree, {
+            name: 'demo',
+            rootProject: true,
+          });
+          const originalBaseTsConfig = readJson(tree, 'tsconfig.json');
 
-    // ACT
-    await libraryGenerator(tree, {
-      name: 'test',
-      style: 'css',
-      buildable: true,
-    });
+          // ACT
+          await libraryGenerator(tree, {
+            name: 'test',
+            style: 'css',
+            projectNameAndRootFormat,
+          });
 
-    // ASSERT
-    const project = readProjectConfiguration(tree, 'test');
-    const pkgJson = readJson(tree, 'libs/test/package.json');
-    expect(project.targets.build.options.format).toEqual(['cjs']);
-    expect(project.targets.build.options.outputPath).toEqual('libs/test/dist');
-    expect(pkgJson.main).toEqual('./dist/index.cjs.js');
-    expect(pkgJson.typings).toEqual('./dist/index.d.ts');
-  });
+          // ASSERT
+          const updatedBaseTsConfig = readJson(tree, 'tsconfig.base.json');
+          expect(
+            Object.keys(originalBaseTsConfig.compilerOptions.paths)
+          ).toContain('~/*');
+          expect(
+            Object.keys(updatedBaseTsConfig.compilerOptions.paths)
+          ).toContain('~/*');
+        });
+      });
+
+      describe('--unitTestRunner', () => {
+        it('should not create config files when unitTestRunner=none', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+          // ACT
+          await libraryGenerator(tree, {
+            name: 'test',
+            style: 'css',
+            unitTestRunner: 'none',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expect(tree.exists(`${libDir}/jest.config.ts`)).toBeFalsy();
+          expect(tree.exists(`${libDir}/vite.config.ts`)).toBeFalsy();
+        });
+
+        it('should create the correct config files for testing with jest', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+          // ACT
+          await libraryGenerator(tree, {
+            name: 'test',
+            style: 'css',
+            unitTestRunner: 'jest',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expect(
+            tree.read(`${libDir}/jest.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+          expect(tree.read(`${libDir}/src/test-setup.ts`, 'utf-8'))
+            .toMatchInlineSnapshot(`
+                    "import { installGlobals } from '@remix-run/node';
+                    import '@testing-library/jest-dom/extend-expect';
+                    installGlobals();
+                    "
+                `);
+        });
+
+        it('should create the correct config files for testing with vitest', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+          // ACT
+          await libraryGenerator(tree, {
+            name: 'test',
+            style: 'css',
+            unitTestRunner: 'vitest',
+            projectNameAndRootFormat,
+          });
+
+          // ASSERT
+          expect(
+            tree.read(`${libDir}/vite.config.ts`, 'utf-8')
+          ).toMatchSnapshot();
+
+          expect(tree.read(`${libDir}/src/test-setup.ts`, 'utf-8'))
+            .toMatchInlineSnapshot(`
+                    "import { installGlobals } from '@remix-run/node';
+                    import '@testing-library/jest-dom/extend-expect';
+                    installGlobals();
+                    "
+                `);
+        }, 25_000);
+      });
+
+      // TODO(Colum): Unskip this when buildable is investigated correctly
+      xit('should generate the config files correctly when the library is buildable', async () => {
+        // ARRANGE
+        const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+        // ACT
+        await libraryGenerator(tree, {
+          name: 'test',
+          style: 'css',
+          buildable: true,
+          projectNameAndRootFormat,
+        });
+
+        // ASSERT
+        const project = readProjectConfiguration(tree, 'test');
+        const pkgJson = readJson(tree, `${libDir}/package.json`);
+        expect(project.targets.build.options.format).toEqual(['cjs']);
+        expect(project.targets.build.options.outputPath).toEqual(
+          `${libDir}/dist`
+        );
+        expect(pkgJson.main).toEqual('./dist/index.cjs.js');
+        expect(pkgJson.typings).toEqual('./dist/index.d.ts');
+      });
+    }
+  );
 });

--- a/packages/remix/src/generators/library/library.impl.ts
+++ b/packages/remix/src/generators/library/library.impl.ts
@@ -12,15 +12,16 @@ import type { NxRemixGeneratorSchema } from './schema';
 
 export default async function (tree: Tree, schema: NxRemixGeneratorSchema) {
   const tasks: GeneratorCallback[] = [];
-  const options = normalizeOptions(tree, schema);
+  const options = await normalizeOptions(tree, schema);
 
   const libGenTask = await libraryGenerator(tree, {
-    name: options.name,
+    name: options.projectName,
     style: options.style,
     unitTestRunner: options.unitTestRunner,
     tags: options.tags,
     importPath: options.importPath,
-    directory: options.directory,
+    directory: options.projectRoot,
+    projectNameAndRootFormat: 'as-provided',
     skipFormat: true,
     skipTsConfig: false,
     linter: Linter.EsLint,

--- a/packages/remix/src/generators/library/schema.d.ts
+++ b/packages/remix/src/generators/library/schema.d.ts
@@ -1,9 +1,11 @@
+import { ProjectNameAndRootFormat } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { SupportedStyles } from '@nx/react';
 
 export interface NxRemixGeneratorSchema {
   name: string;
   style: SupportedStyles;
   directory?: string;
+  projectNameAndRootFormat?: ProjectNameAndRootFormat;
   tags?: string;
   importPath?: string;
   buildable?: boolean;

--- a/packages/remix/src/generators/library/schema.json
+++ b/packages/remix/src/generators/library/schema.json
@@ -26,6 +26,14 @@
       "alias": "dir",
       "x-priority": "important"
     },
+    "projectNameAndRootFormat": {
+      "description": "Whether to generate the project name and root directory as provided (`as-provided`) or generate them composing their values and taking the configured layout into account (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
+    },
     "tags": {
       "type": "string",
       "description": "Add tags to the library (used for linting)"
@@ -33,7 +41,10 @@
     "style": {
       "type": "string",
       "description": "Generate a stylesheet",
-      "enum": ["none", "css"],
+      "enum": [
+        "none",
+        "css"
+      ],
       "default": "css"
     },
     "buildable": {
@@ -43,7 +54,11 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "vitest", "none"],
+      "enum": [
+        "jest",
+        "vitest",
+        "none"
+      ],
       "description": "Test Runner to use for Unit Tests",
       "x-prompt": "What test runner should be used?",
       "default": "vitest"
@@ -64,5 +79,7 @@
       "x-priority": "internal"
     }
   },
-  "required": ["name"]
+  "required": [
+    "name"
+  ]
 }


### PR DESCRIPTION
Add `projectNameAndRootFormat` to Library generator for consistency
