### PR TITLE
feat(remix): add consistent path generation to artefacts

### DIFF
--- a/packages/remix/src/generators/action/action.impl.spec.ts
+++ b/packages/remix/src/generators/action/action.impl.spec.ts
@@ -67,4 +67,24 @@ describe('action', () => {
       });
     });
   });
+
+  it('--nameAndDirectoryFormat=as-provided', async () => {
+    // ACT
+    await actionGenerator(tree, {
+      path: 'apps/demo/app/routes/example.tsx',
+    });
+    // ASSERT
+    const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
+    const useActionData = `const actionMessage = useActionData<typeof action>();`;
+    const actionFunction = `export const action = async ({ request }: ActionArgs)`;
+    expect(content).toMatch(`import { json } from '@remix-run/node';`);
+    expect(content).toMatch(
+      `import type { ActionArgs } from '@remix-run/node';`
+    );
+    expect(content).toMatch(
+      `import { useActionData } from '@remix-run/react';`
+    );
+    expect(content).toMatch(useActionData);
+    expect(content).toMatch(actionFunction);
+  });
 });

--- a/packages/remix/src/generators/action/action.impl.ts
+++ b/packages/remix/src/generators/action/action.impl.ts
@@ -6,11 +6,10 @@ import { resolveRemixRouteFile } from '../../utils/remix-route-utils';
 import { LoaderSchema } from './schema';
 
 export default async function (tree: Tree, schema: LoaderSchema) {
-  const routeFilePath = resolveRemixRouteFile(
-    tree,
-    schema.path,
-    schema.project
-  );
+  const routeFilePath =
+    schema.nameAndDirectoryFormat === 'as-provided'
+      ? schema.path
+      : resolveRemixRouteFile(tree, schema.path, schema.project);
 
   if (!tree.exists(routeFilePath)) {
     throw new Error(

--- a/packages/remix/src/generators/action/schema.d.ts
+++ b/packages/remix/src/generators/action/schema.d.ts
@@ -1,4 +1,10 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface LoaderSchema {
   path: string;
-  project: string;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project?: string;
 }

--- a/packages/remix/src/generators/action/schema.json
+++ b/packages/remix/src/generators/action/schema.json
@@ -10,7 +10,15 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar.tsx')"
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the action in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
     },
     "project": {
       "type": "string",
@@ -19,8 +27,11 @@
         "$source": "projectName"
       },
       "x-prompt": "What project is this route for?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     }
   },
-  "required": ["path", "project"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/error-boundary/__snapshots__/error-boundary.impl.spec.ts.snap
+++ b/packages/remix/src/generators/error-boundary/__snapshots__/error-boundary.impl.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ErrorBoundary --apiVersion=1 should correctly add the ErrorBoundary to the route file 1`] = `
+exports[`ErrorBoundary --nameAndDirectoryFormat=as-provided --apiVersion=1 should correctly add the ErrorBoundary to the route file 1`] = `
 "export function ErrorBoundary({ error }) {
   console.error(error);
   return (
@@ -14,7 +14,55 @@ exports[`ErrorBoundary --apiVersion=1 should correctly add the ErrorBoundary to 
 "
 `;
 
-exports[`ErrorBoundary --apiVersion=2 should correctly add the ErrorBoundary to the route file 1`] = `
+exports[`ErrorBoundary --nameAndDirectoryFormat=as-provided --apiVersion=1 should correctly add the ErrorBoundary to the route file 2`] = `
+"export function ErrorBoundary({ error }) {
+  console.error(error);
+  return (
+    <div>
+      <h1>Uh oh ...</h1>
+      <p>Something went wrong</p>
+      <pre>{error.message || 'Unknown error'}</pre>
+    </div>
+  );
+}
+"
+`;
+
+exports[`ErrorBoundary --nameAndDirectoryFormat=as-provided --apiVersion=2 should correctly add the ErrorBoundary to the route file 1`] = `
+"import { isRouteErrorResponse, useRouteError } from '@remix-run/react';
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  // when true, this is what used to go to 'CatchBoundary'
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div>
+        <h1>Oops</h1>
+        <p>Status: {error.status}</p>
+        <p>{error.data.message}</p>
+      </div>
+    );
+  }
+
+  // Don't forget to typecheck with your own logic.
+  // Any value can be thrown, not just errors!
+  let errorMessage = 'Unknown error';
+  // if (isDefinitelyAnError(error)) {
+  //    errorMessage = error.message;
+  // }
+
+  return (
+    <div>
+      <h1>Uh oh ...</h1>
+      <p>Something went wrong.</p>
+      <pre>{errorMessage}</pre>
+    </div>
+  );
+}
+"
+`;
+
+exports[`ErrorBoundary --nameAndDirectoryFormat=as-provided --apiVersion=2 should correctly add the ErrorBoundary to the route file 2`] = `
 "import { isRouteErrorResponse, useRouteError } from '@remix-run/react';
 export function ErrorBoundary() {
   const error = useRouteError();

--- a/packages/remix/src/generators/error-boundary/error-boundary.impl.spec.ts
+++ b/packages/remix/src/generators/error-boundary/error-boundary.impl.spec.ts
@@ -1,103 +1,119 @@
 import { addProjectConfiguration } from '@nx/devkit';
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import errorBoundaryGenerator from './error-boundary.impl';
 
 describe('ErrorBoundary', () => {
-  describe('--apiVersion=1', () => {
-    it('should correctly add the ErrorBoundary to the route file', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace();
-      addProjectConfiguration(tree, 'demo', {
-        name: 'demo',
-        root: '.',
-        sourceRoot: '.',
-        projectType: 'application',
-      });
-      const routeFilePath = `app/routes/test.tsx`;
-      tree.write(routeFilePath, ``);
-      tree.write('remix.config.js', `module.exports = {}`);
+  describe.each([
+    ['derived', 'app/routes/test.tsx', 'demo'],
+    ['as-provided', 'app/routes/test.tsx', ''],
+  ])(
+    `--nameAndDirectoryFormat=as-provided`,
+    (
+      nameAndDirectoryFormat: NameAndDirectoryFormat,
+      routeFilePath: string,
+      project: string
+    ) => {
+      describe('--apiVersion=1', () => {
+        it('should correctly add the ErrorBoundary to the route file', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace();
+          addProjectConfiguration(tree, 'demo', {
+            name: 'demo',
+            root: '.',
+            sourceRoot: '.',
+            projectType: 'application',
+          });
+          tree.write(routeFilePath, ``);
+          tree.write('remix.config.js', `module.exports = {}`);
 
-      // ACT
-      await errorBoundaryGenerator(tree, {
-        project: 'demo',
-        path: routeFilePath,
-        apiVersion: 1,
-      });
+          // ACT
+          await errorBoundaryGenerator(tree, {
+            project,
+            path: routeFilePath,
+            nameAndDirectoryFormat,
+            apiVersion: 1,
+          });
 
-      // ASSERT
-      expect(tree.read(routeFilePath, 'utf-8')).toMatchSnapshot();
-    });
+          // ASSERT
+          expect(tree.read(routeFilePath, 'utf-8')).toMatchSnapshot();
+        });
 
-    it('should error when the route file cannot be found', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace();
-      addProjectConfiguration(tree, 'demo', {
-        name: 'demo',
-        root: '.',
-        sourceRoot: '.',
-        projectType: 'application',
-      });
-      const routeFilePath = `app/routes/test.tsx`;
-      tree.write(routeFilePath, ``);
-      tree.write('remix.config.js', `module.exports = {}`);
+        it('should error when the route file cannot be found', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace();
+          addProjectConfiguration(tree, 'demo', {
+            name: 'demo',
+            root: '.',
+            sourceRoot: '.',
+            projectType: 'application',
+          });
+          const routeFilePath = `app/routes/test.tsx`;
+          tree.write(routeFilePath, ``);
+          tree.write('remix.config.js', `module.exports = {}`);
 
-      // ACT & ASSERT
-      await expect(
-        errorBoundaryGenerator(tree, {
-          project: 'demo',
-          path: `my-route.tsx`,
-          apiVersion: 1,
-        })
-      ).rejects.toThrow();
-    });
-  });
-
-  describe('--apiVersion=2', () => {
-    it('should correctly add the ErrorBoundary to the route file', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace();
-      addProjectConfiguration(tree, 'demo', {
-        name: 'demo',
-        root: '.',
-        sourceRoot: '.',
-        projectType: 'application',
-      });
-      const routeFilePath = `app/routes/test.tsx`;
-      tree.write(routeFilePath, ``);
-      tree.write('remix.config.js', `module.exports = {}`);
-
-      // ACT
-      await errorBoundaryGenerator(tree, {
-        project: 'demo',
-        path: routeFilePath,
-        apiVersion: 2,
+          // ACT & ASSERT
+          await expect(
+            errorBoundaryGenerator(tree, {
+              project,
+              nameAndDirectoryFormat,
+              path: `my-route.tsx`,
+              apiVersion: 1,
+            })
+          ).rejects.toThrow();
+        });
       });
 
-      // ASSERT
-      expect(tree.read(routeFilePath, 'utf-8')).toMatchSnapshot();
-    });
+      describe('--apiVersion=2', () => {
+        it('should correctly add the ErrorBoundary to the route file', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace();
+          addProjectConfiguration(tree, 'demo', {
+            name: 'demo',
+            root: '.',
+            sourceRoot: '.',
+            projectType: 'application',
+          });
+          const routeFilePath = `app/routes/test.tsx`;
+          tree.write(routeFilePath, ``);
+          tree.write('remix.config.js', `module.exports = {}`);
 
-    it('should error when the route file cannot be found', async () => {
-      // ARRANGE
-      const tree = createTreeWithEmptyWorkspace();
-      addProjectConfiguration(tree, 'demo', {
-        name: 'demo',
-        root: '.',
-        sourceRoot: '.',
-        projectType: 'application',
+          // ACT
+          await errorBoundaryGenerator(tree, {
+            project,
+            path: routeFilePath,
+            nameAndDirectoryFormat,
+            apiVersion: 2,
+          });
+
+          // ASSERT
+          expect(tree.read(routeFilePath, 'utf-8')).toMatchSnapshot();
+        });
+
+        it('should error when the route file cannot be found', async () => {
+          // ARRANGE
+          const tree = createTreeWithEmptyWorkspace();
+          addProjectConfiguration(tree, 'demo', {
+            name: 'demo',
+            root: '.',
+            sourceRoot: '.',
+            projectType: 'application',
+          });
+          const routeFilePath = `app/routes/test.tsx`;
+          tree.write(routeFilePath, ``);
+          tree.write('remix.config.js', `module.exports = {}`);
+
+          // ACT & ASSERT
+          await expect(
+            errorBoundaryGenerator(tree, {
+              project,
+              nameAndDirectoryFormat,
+              path: `my-route.tsx`,
+              apiVersion: 2,
+            })
+          ).rejects.toThrow();
+        });
       });
-      const routeFilePath = `app/routes/test.tsx`;
-      tree.write(routeFilePath, ``);
-      tree.write('remix.config.js', `module.exports = {}`);
-
-      // ACT & ASSERT
-      await expect(
-        errorBoundaryGenerator(tree, {
-          project: 'demo',
-          path: `my-route.tsx`,
-          apiVersion: 2,
-        })
-      ).rejects.toThrow();
-    });
-  });
+    }
+  );
 });

--- a/packages/remix/src/generators/error-boundary/lib/normalize-options.ts
+++ b/packages/remix/src/generators/error-boundary/lib/normalize-options.ts
@@ -6,15 +6,14 @@ export function normalizeOptions(
   tree: Tree,
   schema: ErrorBoundarySchema
 ): ErrorBoundarySchema {
-  const pathToRouteFile = resolveRemixRouteFile(
-    tree,
-    schema.path,
-    schema.project
-  );
+  const pathToRouteFile =
+    schema.nameAndDirectoryFormat === 'as-provided'
+      ? schema.path
+      : resolveRemixRouteFile(tree, schema.path, schema.project);
 
   if (!tree.exists(pathToRouteFile)) {
     throw new Error(
-      `Route file specified does not exist "${pathToRouteFile}". Please ensure you pass a correct path to the file, relative to the project root.`
+      `Route file specified does not exist "${pathToRouteFile}". Please ensure you pass a correct path to the file.`
     );
   }
 

--- a/packages/remix/src/generators/error-boundary/schema.d.ts
+++ b/packages/remix/src/generators/error-boundary/schema.d.ts
@@ -1,6 +1,12 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface ErrorBoundarySchema {
-  project: string;
   path: string;
   apiVersion: number;
   skipFormat?: false;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project?: string;
 }

--- a/packages/remix/src/generators/error-boundary/schema.json
+++ b/packages/remix/src/generators/error-boundary/schema.json
@@ -5,11 +5,23 @@
   "type": "object",
   "examples": [
     {
-      "command": "g error-boundary --project=myapp --routePath=app/routes/my-route.tsx",
+      "command": "g error-boundary --routePath=apps/demo/app/routes/my-route.tsx",
       "description": "Generate an ErrorBoundary for my-route.tsx"
     }
   ],
   "properties": {
+    "path": {
+      "type": "string",
+      "description": "The path to route file relative to the project root."
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the error boundary in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
+    },
     "project": {
       "type": "string",
       "description": "The name of the project.",
@@ -17,11 +29,8 @@
         "$source": "projectName"
       },
       "x-prompt": "What project contains the route file that this ErrorBoundary is for?",
-      "pattern": "^[a-zA-Z].*$"
-    },
-    "path": {
-      "type": "string",
-      "description": "The path to route file relative to the project root."
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     },
     "apiVersion": {
       "type": "number",
@@ -35,5 +44,7 @@
       "x-priority": "internal"
     }
   },
-  "required": ["project", "path"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/loader/loader.impl.spec.ts
+++ b/packages/remix/src/generators/loader/loader.impl.spec.ts
@@ -67,4 +67,24 @@ describe('loader', () => {
       });
     });
   });
+
+  describe('--nameAndDirectoryFormat=as-provided', () => {
+    it('should add imports', async () => {
+      // ACT
+      await loaderGenerator(tree, {
+        path: 'apps/demo/app/routes/example.tsx',
+        nameAndDirectoryFormat: 'as-provided',
+      });
+
+      // ASSERT
+      const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
+      expect(content).toMatch(`import { json } from '@remix-run/node';`);
+      expect(content).toMatch(
+        `import type { LoaderArgs } from '@remix-run/node';`
+      );
+      expect(content).toMatch(
+        `import { useLoaderData } from '@remix-run/react';`
+      );
+    });
+  });
 });

--- a/packages/remix/src/generators/loader/loader.impl.ts
+++ b/packages/remix/src/generators/loader/loader.impl.ts
@@ -6,11 +6,10 @@ import { resolveRemixRouteFile } from '../../utils/remix-route-utils';
 import { LoaderSchema } from './schema';
 
 export default async function (tree: Tree, schema: LoaderSchema) {
-  const routeFilePath = resolveRemixRouteFile(
-    tree,
-    schema.path,
-    schema.project
-  );
+  const routeFilePath =
+    schema.nameAndDirectoryFormat === 'as-provided'
+      ? schema.path
+      : resolveRemixRouteFile(tree, schema.path, schema.project);
 
   if (!tree.exists(routeFilePath)) {
     throw new Error(

--- a/packages/remix/src/generators/loader/schema.d.ts
+++ b/packages/remix/src/generators/loader/schema.d.ts
@@ -1,4 +1,10 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface LoaderSchema {
-  project: string;
   path: string;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project?: string;
 }

--- a/packages/remix/src/generators/loader/schema.json
+++ b/packages/remix/src/generators/loader/schema.json
@@ -10,10 +10,10 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar.tsx')"
     },
     "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "description": "Whether to generate the loader in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
       "type": "string",
       "enum": [
         "as-provided",

--- a/packages/remix/src/generators/loader/schema.json
+++ b/packages/remix/src/generators/loader/schema.json
@@ -10,7 +10,15 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
     },
     "project": {
       "type": "string",
@@ -19,8 +27,11 @@
         "$source": "projectName"
       },
       "x-prompt": "What project is this route for?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     }
   },
-  "required": ["path", "project"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/meta/lib/normalize-options.ts
+++ b/packages/remix/src/generators/meta/lib/normalize-options.ts
@@ -1,13 +1,24 @@
 import { Tree } from '@nx/devkit';
+import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { getRemixFutureFlags } from '../../../utils/remix-config';
 import { MetaSchema } from '../schema';
 
-export function normalizeOptions(tree: Tree, options: MetaSchema): MetaSchema {
+export async function normalizeOptions(
+  tree: Tree,
+  options: MetaSchema
+): Promise<MetaSchema> {
+  const { project } = await determineArtifactNameAndDirectoryOptions(tree, {
+    artifactType: 'meta',
+    callingGenerator: '@nx/remix:meta',
+    name: options.path,
+    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    project: options.project,
+  });
   let normalizedVersion = options.version;
 
   if (!normalizedVersion) {
     // is the v2 future flag enabled?
-    const futureFlags = getRemixFutureFlags(tree, options.project);
+    const futureFlags = getRemixFutureFlags(tree, project);
 
     normalizedVersion = futureFlags?.v2_meta ? '2' : '1';
   }

--- a/packages/remix/src/generators/meta/lib/v1.impl.ts
+++ b/packages/remix/src/generators/meta/lib/v1.impl.ts
@@ -6,11 +6,10 @@ import { resolveRemixRouteFile } from '../../../utils/remix-route-utils';
 import { MetaSchema } from '../schema';
 
 export async function v1MetaGenerator(tree: Tree, schema: MetaSchema) {
-  const routeFilePath = resolveRemixRouteFile(
-    tree,
-    schema.path,
-    schema.project
-  );
+  const routeFilePath =
+    schema.nameAndDirectoryFormat === 'as-provided'
+      ? schema.path
+      : resolveRemixRouteFile(tree, schema.path, schema.project);
 
   if (!tree.exists(routeFilePath)) {
     throw new Error(

--- a/packages/remix/src/generators/meta/lib/v2.impl.ts
+++ b/packages/remix/src/generators/meta/lib/v2.impl.ts
@@ -6,11 +6,10 @@ import { resolveRemixRouteFile } from '../../../utils/remix-route-utils';
 import { MetaSchema } from '../schema';
 
 export async function v2MetaGenerator(tree: Tree, schema: MetaSchema) {
-  const routeFilePath = resolveRemixRouteFile(
-    tree,
-    schema.path,
-    schema.project
-  );
+  const routeFilePath =
+    schema.nameAndDirectoryFormat === 'as-provided'
+      ? schema.path
+      : resolveRemixRouteFile(tree, schema.path, schema.project);
 
   if (!tree.exists(routeFilePath)) {
     throw new Error(

--- a/packages/remix/src/generators/meta/meta.impl.spec.ts
+++ b/packages/remix/src/generators/meta/meta.impl.spec.ts
@@ -77,4 +77,20 @@ describe('meta', () => {
     expect(content).toMatch(`export const meta: V2_MetaFunction`);
     expect(content).toMatch(`return [`);
   });
+
+  it('--nameAndDirectoryFormat=as=provided', async () => {
+    await metaGenerator(tree, {
+      path: 'apps/demo/app/routes/example.tsx',
+      nameAndDirectoryFormat: 'as-provided',
+      version: '2',
+    });
+
+    const content = tree.read('apps/demo/app/routes/example.tsx', 'utf-8');
+    expect(content).toMatch(
+      `import type { V2_MetaFunction } from '@remix-run/node';`
+    );
+
+    expect(content).toMatch(`export const meta: V2_MetaFunction`);
+    expect(content).toMatch(`return [`);
+  });
 });

--- a/packages/remix/src/generators/meta/meta.impl.ts
+++ b/packages/remix/src/generators/meta/meta.impl.ts
@@ -6,7 +6,7 @@ import { v1MetaGenerator } from './lib/v1.impl';
 import { v2MetaGenerator } from './lib/v2.impl';
 
 export default async function (tree: Tree, schema: MetaSchema) {
-  const options = normalizeOptions(tree, schema);
+  const options = await normalizeOptions(tree, schema);
 
   if (options.version === '1') {
     await v1MetaGenerator(tree, options);

--- a/packages/remix/src/generators/meta/schema.d.ts
+++ b/packages/remix/src/generators/meta/schema.d.ts
@@ -1,5 +1,11 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface MetaSchema {
   path: string;
-  project: string;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   version?: '1' | '2';
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project?: string;
 }

--- a/packages/remix/src/generators/meta/schema.json
+++ b/packages/remix/src/generators/meta/schema.json
@@ -10,7 +10,7 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar.tsx')"
     },
     "nameAndDirectoryFormat": {
       "description": "Whether to generate the meta function in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",

--- a/packages/remix/src/generators/meta/schema.json
+++ b/packages/remix/src/generators/meta/schema.json
@@ -13,7 +13,7 @@
       "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
     },
     "nameAndDirectoryFormat": {
-      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "description": "Whether to generate the meta function in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
       "type": "string",
       "enum": [
         "as-provided",

--- a/packages/remix/src/generators/meta/schema.json
+++ b/packages/remix/src/generators/meta/schema.json
@@ -12,6 +12,14 @@
       },
       "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
     },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the component in the directory as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
+    },
     "project": {
       "type": "string",
       "description": "The name of the project.",
@@ -19,12 +27,15 @@
         "$source": "projectName"
       },
       "x-prompt": "What project is this route for?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     },
     "version": {
       "type": "string",
       "description": "The version of the meta convention to use"
     }
   },
-  "required": ["path", "project"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/resource-route/__snapshots__/resource-route.impl.spec.ts.snap
+++ b/packages/remix/src/generators/resource-route/__snapshots__/resource-route.impl.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resource route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 3`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 4`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 6`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 3`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 4`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 6`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 7`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`resource route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 9`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;

--- a/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
+++ b/packages/remix/src/generators/resource-route/resource-route.impl.spec.ts
@@ -1,5 +1,7 @@
 import { Tree } from '@nx/devkit';
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { dirname } from 'path';
 import applicationGenerator from '../application/application.impl';
 import resourceRouteGenerator from './resource-route.impl';
 
@@ -40,99 +42,114 @@ describe('resource route', () => {
     );
   });
 
-  [
-    {
-      path: 'apps/demo/app/routes/example.ts',
-    },
-    {
-      path: 'example',
-    },
-    {
-      path: 'example.ts',
-    },
-  ].forEach((config) => {
-    it(`should create correct file for path ${config.path}`, async () => {
-      await resourceRouteGenerator(tree, {
-        project: 'demo',
-        path: config.path,
-        action: false,
-        loader: true,
-        skipChecks: false,
+  describe.each([
+    ['derived', 'apps/demo/app/routes/example.ts', 'demo'],
+    ['derived', 'example', 'demo'],
+    ['derived', 'example.ts', 'demo'],
+    ['as-provided', 'apps/demo/app/routes/example', ''],
+    ['as-provided', 'apps/demo/app/routes/example.ts', ''],
+  ])(
+    '--nameAndDirectoryFormat=%s',
+    (
+      nameAndDirectoryFormat: NameAndDirectoryFormat,
+      path: string,
+      project: string
+    ) => {
+      it(`should create correct file for path ${path}`, async () => {
+        await resourceRouteGenerator(tree, {
+          project,
+          path,
+          action: false,
+          loader: true,
+          skipChecks: false,
+          nameAndDirectoryFormat,
+        });
+
+        expect(tree.exists('apps/demo/app/routes/example.ts')).toBeTruthy();
       });
 
-      expect(tree.exists('apps/demo/app/routes/example.ts')).toBeTruthy();
-    });
-  });
+      it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
+        expect.assertions(3);
 
-  it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
-    expect.assertions(3);
+        await resourceRouteGenerator(tree, {
+          project,
+          path: `${dirname(path)}/route1/.ts`, // route.$withParams.tsx => route..tsx
+          loader: true,
+          action: true,
+          skipChecks: false,
+          nameAndDirectoryFormat,
+        }).catch((e) => expect(e).toMatchSnapshot());
 
-    await resourceRouteGenerator(tree, {
-      project: 'demo',
-      path: 'route1/.ts', // route.$withParams.tsx => route..tsx
-      loader: true,
-      action: true,
-      skipChecks: false,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
-      )
-    );
+        await resourceRouteGenerator(tree, {
+          project,
+          path: `${dirname(path)}/route2//index.ts`, // route/$withParams/index.tsx => route//index.tsx
+          loader: true,
+          action: true,
+          skipChecks: false,
+          nameAndDirectoryFormat,
+        }).catch((e) =>
+          expect(e).toMatchInlineSnapshot(
+            `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
+          )
+        );
 
-    await resourceRouteGenerator(tree, {
-      project: 'demo',
-      path: 'route2//index.ts', // route/$withParams/index.tsx => route//index.tsx
-      loader: true,
-      action: true,
-      skipChecks: false,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
-      )
-    );
+        await resourceRouteGenerator(tree, {
+          project,
+          path: `${dirname(path)}/route3/.ts`, // route/$withParams.tsx => route/.tsx
+          loader: true,
+          action: true,
+          skipChecks: false,
+          nameAndDirectoryFormat,
+        }).catch((e) => expect(e).toMatchSnapshot());
+      });
 
-    await resourceRouteGenerator(tree, {
-      project: 'demo',
-      path: 'route3/.ts', // route/$withParams.tsx => route/.tsx
-      loader: true,
-      action: true,
-      skipChecks: false,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
-      )
-    );
-  });
+      it(`should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign for ${path}`, async () => {
+        const basePath =
+          nameAndDirectoryFormat === 'as-provided'
+            ? ''
+            : 'apps/demo/app/routes';
+        const normalizedPath = (
+          dirname(path) === '' ? '' : `${dirname(path)}/`
+        ).replace(basePath, '');
+        await resourceRouteGenerator(tree, {
+          project,
+          path: `${normalizedPath}route1/..ts`, // route.$withParams.tsx => route..tsx
+          loader: true,
+          action: true,
+          skipChecks: true,
+          nameAndDirectoryFormat,
+        });
 
-  it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
-    await resourceRouteGenerator(tree, {
-      project: 'demo',
-      path: 'route1/..ts', // route.$withParams.tsx => route..tsx
-      loader: true,
-      action: true,
-      skipChecks: true,
-    });
+        expect(tree.exists(`${basePath}/${normalizedPath}route1/..ts`)).toBe(
+          true
+        );
 
-    expect(tree.exists('apps/demo/app/routes/route1/..ts')).toBe(true);
+        await resourceRouteGenerator(tree, {
+          project,
+          path: `${normalizedPath}route2//index.ts`, // route/$withParams/index.tsx => route//index.tsx
+          loader: true,
+          action: true,
+          skipChecks: true,
+          nameAndDirectoryFormat,
+        });
 
-    await resourceRouteGenerator(tree, {
-      project: 'demo',
-      path: 'route2//index.ts', // route/$withParams/index.tsx => route//index.tsx
-      loader: true,
-      action: true,
-      skipChecks: true,
-    });
+        expect(
+          tree.exists(`${basePath}/${normalizedPath}route2/index.ts`)
+        ).toBe(true);
 
-    expect(tree.exists('apps/demo/app/routes/route2/index.ts')).toBe(true);
+        await resourceRouteGenerator(tree, {
+          project,
+          path: `${normalizedPath}route3/.ts`, // route/$withParams.tsx => route/.tsx
+          loader: true,
+          action: true,
+          skipChecks: true,
+          nameAndDirectoryFormat,
+        });
 
-    await resourceRouteGenerator(tree, {
-      project: 'demo',
-      path: 'route3/.ts', // route/$withParams.tsx => route/.tsx
-      loader: true,
-      action: true,
-      skipChecks: true,
-    });
-
-    expect(tree.exists('apps/demo/app/routes/route3/.ts')).toBe(true);
-  });
+        expect(tree.exists(`${basePath}/${normalizedPath}route3/.ts`)).toBe(
+          true
+        );
+      });
+    }
+  );
 });

--- a/packages/remix/src/generators/resource-route/schema.d.ts
+++ b/packages/remix/src/generators/resource-route/schema.d.ts
@@ -1,7 +1,13 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface RemixRouteSchema {
-  project: string;
   path: string;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   action: boolean;
   loader: boolean;
   skipChecks: boolean;
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project?: string;
 }

--- a/packages/remix/src/generators/resource-route/schema.json
+++ b/packages/remix/src/generators/resource-route/schema.json
@@ -17,7 +17,15 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the styles in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
     },
     "project": {
       "type": "string",
@@ -26,7 +34,8 @@
         "$source": "projectName"
       },
       "x-prompt": "What project is this route for?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     },
     "action": {
       "type": "boolean",
@@ -44,5 +53,7 @@
       "default": false
     }
   },
-  "required": ["project", "path"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
+++ b/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
@@ -1,6 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`route should add route component 1`] = `
+exports[`route --nameAndDirectoryFormat=as-provided should add route component 1`] = `
+"import type {
+  ActionArgs,
+  LinksFunction,
+  LoaderArgs,
+  MetaFunction,
+} from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { useActionData, useLoaderData } from '@remix-run/react';
+
+import stylesUrl from '../../../styles/path/to/example.css';
+
+export const links: LinksFunction = () => {
+  return [{ rel: 'stylesheet', href: stylesUrl }];
+};
+
+export const action = async ({ request }: ActionArgs) => {
+  let formData = await request.formData();
+
+  return json({ message: formData.toString() }, { status: 200 });
+};
+
+export const meta: MetaFunction = () => {
+  return { title: 'Example Route' };
+};
+
+export const loader = async ({ request }: LoaderArgs) => {
+  return json({
+    message: 'Hello, world!',
+  });
+};
+
+export default function Example() {
+  const actionMessage = useActionData<typeof action>();
+  const data = useLoaderData<typeof loader>();
+
+  return <p>Message: {data.message}</p>;
+}
+"
+`;
+
+exports[`route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 2`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`route --nameAndDirectoryFormat=as-provided should error if it detects a possible missing route param because of un-escaped dollar sign 3`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`route --nameAndDirectoryFormat=derived should add route component 1`] = `
 "import type {
   ActionArgs,
   LinksFunction,
@@ -40,3 +87,9 @@ export default function PathToExample() {
 }
 "
 `;
+
+exports[`route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 2`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
+
+exports[`route --nameAndDirectoryFormat=derived should error if it detects a possible missing route param because of un-escaped dollar sign 3`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;

--- a/packages/remix/src/generators/route/route.impl.spec.ts
+++ b/packages/remix/src/generators/route/route.impl.spec.ts
@@ -1,4 +1,5 @@
 import { Tree } from '@nx/devkit';
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import applicationGenerator from '../application/application.impl';
 import presetGenerator from '../preset/preset.impl';
@@ -11,194 +12,226 @@ describe('route', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     tree.write('.gitignore', `/node_modules/dist`);
   });
-
-  it('should add route component', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'path/to/example',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
-
-    const content = tree.read(
+  describe.each([
+    [
+      'derived',
+      'path/to/example',
+      '',
       'apps/demo/app/routes/path/to/example.tsx',
-      'utf-8'
-    );
-    expect(content).toMatchSnapshot();
-    expect(content).toMatch('LinksFunction');
-    expect(content).toMatch('function PathToExample(');
-    expect(
-      tree.exists('apps/demo/app/styles/path/to/example.css')
-    ).toBeTruthy();
-  }, 25_000);
+      'apps/demo/app/styles/path/to/example.css',
+      'PathToExample',
+      'demo',
+    ],
+    [
+      'as-provided',
+      'apps/demo/app/routes/path/to/example',
+      'app/routes',
+      'apps/demo/app/routes/path/to/example.tsx',
+      'apps/demo/app/styles/path/to/example.css',
+      'Example',
+      '',
+    ],
+  ])(
+    `--nameAndDirectoryFormat=%s`,
+    (
+      nameAndDirectoryFormat: NameAndDirectoryFormat,
+      path,
+      standalonePath,
+      expectedRoutePath,
+      expectedStylePath,
+      expectedComponentName,
+      project: string
+    ) => {
+      it('should add route component', async () => {
+        await applicationGenerator(tree, { name: 'demo' });
+        await routeGenerator(tree, {
+          project,
+          path,
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        });
 
-  it('should support --style=none', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'example',
-      style: 'none',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
+        const content = tree.read(expectedRoutePath, 'utf-8');
+        expect(content).toMatchSnapshot();
+        expect(content).toMatch('LinksFunction');
+        expect(content).toMatch(`function ${expectedComponentName}(`);
+        expect(tree.exists(expectedStylePath)).toBeTruthy();
+      }, 25_000);
 
-    const content = tree.read('apps/demo/app/routes/example.tsx').toString();
-    expect(content).not.toMatch('LinksFunction');
-    expect(tree.exists('apps/demo/app/styles/example.css')).toBeFalsy();
-  });
+      it('should support --style=none', async () => {
+        await applicationGenerator(tree, { name: 'demo' });
+        await routeGenerator(tree, {
+          project,
+          path,
+          nameAndDirectoryFormat,
+          style: 'none',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        });
 
-  it('should handle trailing and prefix slashes', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: '/example/',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
+        const content = tree.read(expectedRoutePath).toString();
+        expect(content).not.toMatch('LinksFunction');
+        expect(tree.exists(expectedStylePath)).toBeFalsy();
+      });
 
-    const content = tree.read('apps/demo/app/routes/example.tsx').toString();
-    expect(content).toMatch('function Example(');
-  });
+      it('should handle trailing and prefix slashes', async () => {
+        await applicationGenerator(tree, { name: 'demo' });
+        await routeGenerator(tree, {
+          project,
+          path: `/${path}/`,
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        });
 
-  it('should handle routes that end in a file', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: '/example/index.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
+        const content = tree.read(expectedRoutePath).toString();
+        expect(content).toMatch(`function ${expectedComponentName}(`);
+      });
 
-    const content = tree
-      .read('apps/demo/app/routes/example/index.tsx')
-      .toString();
-    expect(content).toMatch('function ExampleIndex(');
-  });
+      it('should handle routes that end in a file', async () => {
+        await applicationGenerator(tree, { name: 'demo' });
+        await routeGenerator(tree, {
+          project: 'demo',
+          path: `${path}.tsx`,
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        });
 
-  it('should handle routes that have a param', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: '/example/$withParam.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
+        const content = tree.read(expectedRoutePath).toString();
+        expect(content).toMatch(`function ${expectedComponentName}(`);
+      });
 
-    const content = tree
-      .read('apps/demo/app/routes/example/$withParam.tsx')
-      .toString();
-    expect(content).toMatch('function ExampleWithParam(');
-  });
+      it('should handle routes that have a param', async () => {
+        const componentName =
+          nameAndDirectoryFormat === 'as-provided'
+            ? 'WithParam'
+            : `${expectedComponentName}WithParam`;
+        await applicationGenerator(tree, { name: 'demo' });
+        await routeGenerator(tree, {
+          project,
+          path: `/${path}/$withParam.tsx`,
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        });
 
-  it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+        const content = tree
+          .read('apps/demo/app/routes/path/to/example/$withParam.tsx')
+          .toString();
+        expect(content).toMatch(`function ${componentName}(`);
+      });
 
-    expect.assertions(3);
+      it('should error if it detects a possible missing route param because of un-escaped dollar sign', async () => {
+        await applicationGenerator(tree, { name: 'demo' });
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route1/.tsx', // route.$withParams.tsx => route..tsx
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
-      )
-    );
+        expect.assertions(3);
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route2//index.tsx', // route/$withParams/index.tsx => route//index.tsx
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
-      )
-    );
+        await routeGenerator(tree, {
+          project,
+          path: `${path}/route1/.tsx`, // route.$withParams.tsx => route..tsx
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        }).catch((e) => expect(e).toMatchSnapshot());
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route3/.tsx', // route/$withParams.tsx => route/.tsx
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    }).catch((e) =>
-      expect(e).toMatchInlineSnapshot(
-        `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`
-      )
-    );
-  });
+        await routeGenerator(tree, {
+          project,
+          path: `${path}/route2//index.tsx`, // route/$withParams/index.tsx => route//index.tsx
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        }).catch((e) => expect(e).toMatchSnapshot());
 
-  it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+        await routeGenerator(tree, {
+          project: 'demo',
+          path: `${path}/route3/.tsx`, // route/$withParams.tsx => route/.tsx
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        }).catch((e) => expect(e).toMatchSnapshot());
+      });
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route1/..tsx', // route.$withParams.tsx => route..tsx
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: true,
-    });
+      it('should succeed if skipChecks flag is passed, and it detects a possible missing route param because of un-escaped dollar sign', async () => {
+        await applicationGenerator(tree, { name: 'demo' });
 
-    expect(tree.exists('apps/demo/app/routes/route1/..tsx')).toBe(true);
+        await routeGenerator(tree, {
+          project,
+          path: `${path}/route1/..tsx`, // route.$withParams.tsx => route..tsx
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: true,
+        });
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route2//index.tsx', // route/$withParams/index.tsx => route//index.tsx
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: true,
-    });
+        expect(
+          tree.exists('apps/demo/app/routes/path/to/example/route1/..tsx')
+        ).toBe(true);
 
-    expect(tree.exists('apps/demo/app/routes/route2/index.tsx')).toBe(true);
+        await routeGenerator(tree, {
+          project,
+          path: `${path}/route2//index.tsx`, // route/$withParams/index.tsx => route//index.tsx
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: true,
+        });
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route3/.tsx', // route/$withParams.tsx => route/.tsx
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: true,
-    });
+        expect(
+          tree.exists('apps/demo/app/routes/path/to/example/route2/index.tsx')
+        ).toBe(true);
 
-    expect(tree.exists('apps/demo/app/routes/route3/.tsx')).toBe(true);
-  }, 120000);
+        await routeGenerator(tree, {
+          project,
+          path: `${path}/route3/.tsx`, // route/$withParams.tsx => route/.tsx
+          nameAndDirectoryFormat,
+          style: 'css',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: true,
+        });
 
-  it('should place routes correctly when app dir is changed', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+        expect(
+          tree.exists('apps/demo/app/routes/path/to/example/route3/.tsx')
+        ).toBe(true);
+      }, 120000);
 
-    tree.write(
-      'apps/demo/remix.config.js',
-      `
+      if (nameAndDirectoryFormat === 'derived') {
+        it('should place routes correctly when app dir is changed', async () => {
+          await applicationGenerator(tree, { name: 'demo' });
+
+          tree.write(
+            'apps/demo/remix.config.js',
+            `
     /**
      * @type {import('@remix-run/dev').AppConfig}
      */
@@ -206,109 +239,44 @@ describe('route', () => {
       ignoredRouteFiles: ["**/.*"],
       appDirectory: "my-custom-dir",
     };`
-    );
+          );
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
+          await routeGenerator(tree, {
+            project: 'demo',
+            path: 'route.tsx',
+            nameAndDirectoryFormat,
+            style: 'css',
+            loader: true,
+            action: true,
+            meta: true,
+            skipChecks: false,
+          });
 
-    expect(tree.exists('apps/demo/my-custom-dir/routes/route.tsx')).toBe(true);
-    expect(tree.exists('apps/demo/my-custom-dir/styles/route.css')).toBe(true);
-  });
+          expect(tree.exists('apps/demo/my-custom-dir/routes/route.tsx')).toBe(
+            true
+          );
+          expect(tree.exists('apps/demo/my-custom-dir/styles/route.css')).toBe(
+            true
+          );
+        });
+      }
 
-  it('should normalize route paths', async () => {
-    await applicationGenerator(tree, { name: 'demo' });
+      it('should place the route correctly in a standalone app', async () => {
+        await presetGenerator(tree, { name: 'demo' });
 
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'routeRelativeToRoutesDir.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
+        await routeGenerator(tree, {
+          project,
+          path: `${standalonePath}/route.tsx`,
+          nameAndDirectoryFormat,
+          style: 'none',
+          loader: true,
+          action: true,
+          meta: true,
+          skipChecks: false,
+        });
 
-    expect(
-      tree.exists('apps/demo/app/routes/routeRelativeToRoutesDir.tsx')
-    ).toBe(true);
-
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'app/routes/routeRelativeToProjectRoot.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
-
-    expect(
-      tree.exists('apps/demo/app/routes/routeRelativeToProjectRoot.tsx')
-    ).toBe(true);
-
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'apps/demo/app/routes/routeRelativeToWorkspaceRoot.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
-
-    expect(
-      tree.exists('apps/demo/app/routes/routeRelativeToWorkspaceRoot.tsx')
-    ).toBe(true);
-
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'apps/demo/app/routes/route/using/v1/routing.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
-
-    expect(tree.exists('apps/demo/app/routes/route/using/v1/routing.tsx')).toBe(
-      true
-    );
-
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'apps/demo/app/routes/route.using.v2.routing.tsx',
-      style: 'css',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
-
-    expect(tree.exists('apps/demo/app/routes/route.using.v2.routing.tsx')).toBe(
-      true
-    );
-  }, 30000);
-
-  it('should place the route correctly in a standalone app', async () => {
-    await presetGenerator(tree, { name: 'demo' });
-
-    await routeGenerator(tree, {
-      project: 'demo',
-      path: 'route.tsx',
-      style: 'none',
-      loader: true,
-      action: true,
-      meta: true,
-      skipChecks: false,
-    });
-
-    expect(tree.exists('app/routes/route.tsx')).toBe(true);
-  });
+        expect(tree.exists('app/routes/route.tsx')).toBe(true);
+      });
+    }
+  );
 });

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -86,7 +86,7 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
 
   if (options.loader) {
     await LoaderGenerator(tree, {
-      project: projectName,
+      nameAndDirectoryFormat: 'as-provided',
       path: routeFilePath,
     });
   }

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -101,7 +101,7 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
   if (options.action) {
     await ActionGenerator(tree, {
       path: routeFilePath,
-      project: projectName,
+      nameAndDirectoryFormat: 'as-provided',
     });
   }
 

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -86,15 +86,15 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
 
   if (options.loader) {
     await LoaderGenerator(tree, {
-      nameAndDirectoryFormat: 'as-provided',
       path: routeFilePath,
+      nameAndDirectoryFormat: 'as-provided',
     });
   }
 
   if (options.meta) {
     await MetaGenerator(tree, {
       path: routeFilePath,
-      project: projectName,
+      nameAndDirectoryFormat: 'as-provided',
     });
   }
 

--- a/packages/remix/src/generators/route/route.impl.ts
+++ b/packages/remix/src/generators/route/route.impl.ts
@@ -1,10 +1,13 @@
 import {
   formatFiles,
+  joinPathFragments,
   names,
   readProjectConfiguration,
   stripIndents,
   Tree,
 } from '@nx/devkit';
+import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+import { basename, dirname } from 'path';
 import {
   checkRoutePathForErrors,
   resolveRemixRouteFile,
@@ -16,8 +19,20 @@ import StyleGenerator from '../style/style.impl';
 import { RemixRouteSchema } from './schema';
 
 export default async function (tree: Tree, options: RemixRouteSchema) {
-  const project = readProjectConfiguration(tree, options.project);
-  if (!project) throw new Error(`Project does not exist: ${options.project}`);
+  const {
+    artifactName: name,
+    directory,
+    project: projectName,
+  } = await determineArtifactNameAndDirectoryOptions(tree, {
+    artifactType: 'route',
+    callingGenerator: '@nx/remix:route',
+    name: options.path.replace(/^\//, '').replace(/\/$/, ''),
+    nameAndDirectoryFormat: options.nameAndDirectoryFormat,
+    project: options.project,
+  });
+
+  const project = readProjectConfiguration(tree, projectName);
+  if (!project) throw new Error(`Project does not exist: ${projectName}`);
 
   if (!options.skipChecks && checkRoutePathForErrors(options.path)) {
     throw new Error(
@@ -27,13 +42,22 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
 
   const routeFilePath = resolveRemixRouteFile(
     tree,
-    options.path,
-    options.project,
+    options.nameAndDirectoryFormat === 'as-provided'
+      ? joinPathFragments(directory, name)
+      : options.path,
+    options.nameAndDirectoryFormat === 'as-provided' ? undefined : projectName,
     '.tsx'
   );
 
+  const nameToUseForComponent =
+    options.nameAndDirectoryFormat === 'as-provided'
+      ? name.replace('.tsx', '')
+      : options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '');
+
   const { className: componentName } = names(
-    options.path.replace(/^\//, '').replace(/\/$/, '').replace('.tsx', '')
+    nameToUseForComponent === '.' || nameToUseForComponent === ''
+      ? basename(dirname(routeFilePath))
+      : nameToUseForComponent
   );
 
   if (tree.exists(routeFilePath))
@@ -62,7 +86,7 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
 
   if (options.loader) {
     await LoaderGenerator(tree, {
-      project: options.project,
+      project: projectName,
       path: routeFilePath,
     });
   }
@@ -70,21 +94,21 @@ export default async function (tree: Tree, options: RemixRouteSchema) {
   if (options.meta) {
     await MetaGenerator(tree, {
       path: routeFilePath,
-      project: options.project,
+      project: projectName,
     });
   }
 
   if (options.action) {
     await ActionGenerator(tree, {
       path: routeFilePath,
-      project: options.project,
+      project: projectName,
     });
   }
 
   if (options.style === 'css') {
     await StyleGenerator(tree, {
-      project: options.project,
-      path: options.path,
+      project: projectName,
+      path: routeFilePath,
     });
   }
 

--- a/packages/remix/src/generators/route/schema.d.ts
+++ b/packages/remix/src/generators/route/schema.d.ts
@@ -11,5 +11,5 @@ export interface RemixRouteSchema {
   /**
    * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
    */
-  project: string;
+  project?: string;
 }

--- a/packages/remix/src/generators/route/schema.d.ts
+++ b/packages/remix/src/generators/route/schema.d.ts
@@ -1,9 +1,15 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface RemixRouteSchema {
-  project: string;
   path: string;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
   style: 'css' | 'none';
   action: boolean;
   meta: boolean;
   loader: boolean;
   skipChecks: boolean;
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project: string;
 }

--- a/packages/remix/src/generators/route/schema.json
+++ b/packages/remix/src/generators/route/schema.json
@@ -12,12 +12,20 @@
   "properties": {
     "path": {
       "type": "string",
-      "description": "The route path or path to the filename of the route.",
+      "description": "The route path or path to the filename of the route. When `--nameAndDirectoryFormat=as-provided`, it will be relative to the current working directory. Otherwise, it will be relative to the workspace root.",
       "$default": {
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar')"
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the route in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and path relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
     },
     "project": {
       "type": "string",
@@ -26,12 +34,16 @@
         "$source": "projectName"
       },
       "x-prompt": "What project is this route for?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     },
     "style": {
       "type": "string",
       "description": "Generate a stylesheet",
-      "enum": ["none", "css"],
+      "enum": [
+        "none",
+        "css"
+      ],
       "default": "css"
     },
     "meta": {
@@ -55,5 +67,7 @@
       "default": false
     }
   },
-  "required": ["project", "path"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/style/schema.d.ts
+++ b/packages/remix/src/generators/style/schema.d.ts
@@ -1,4 +1,10 @@
+import { NameAndDirectoryFormat } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+
 export interface RemixStyleSchema {
-  project: string;
   path: string;
+  nameAndDirectoryFormat?: NameAndDirectoryFormat;
+  /**
+   * @deprecated Provide the `path` option instead. The project will be determined from the path provided. It will be removed in Nx v18.
+   */
+  project?: string;
 }

--- a/packages/remix/src/generators/style/schema.json
+++ b/packages/remix/src/generators/style/schema.json
@@ -5,8 +5,8 @@
   "type": "object",
   "examples": [
     {
-      "command": "g style --project=webapp --path='path/to/page'",
-      "description": "Generate route at /path/to/page"
+      "command": "g style --path='apps/demo/app/routes/path/to/page.tsx'",
+      "description": "Generate route at apps/demo/app/routes/path/to/page.tsx"
     }
   ],
   "properties": {
@@ -17,7 +17,15 @@
         "$source": "argv",
         "index": 0
       },
-      "x-prompt": "What is the path of the route? (e.g. 'foo/bar')"
+      "x-prompt": "What is the path of the route? (e.g. 'apps/demo/app/routes/foo/bar.tsx')"
+    },
+    "nameAndDirectoryFormat": {
+      "description": "Whether to generate the styles in the path as provided, relative to the current working directory and ignoring the project (`as-provided`) or generate it using the project and directory relative to the workspace root (`derived`).",
+      "type": "string",
+      "enum": [
+        "as-provided",
+        "derived"
+      ]
     },
     "project": {
       "type": "string",
@@ -26,8 +34,11 @@
         "$source": "projectName"
       },
       "x-prompt": "What project is this route in?",
-      "pattern": "^[a-zA-Z].*$"
+      "pattern": "^[a-zA-Z].*$",
+      "x-deprecated": "Provide the `path` option instead and use the `as-provided` format. The project will be determined from the path provided. It will be removed in Nx v18."
     }
   },
-  "required": ["project", "path"]
+  "required": [
+    "path"
+  ]
 }

--- a/packages/remix/src/generators/style/style.impl.spec.ts
+++ b/packages/remix/src/generators/style/style.impl.spec.ts
@@ -135,4 +135,29 @@ describe('route', () => {
       "import stylesUrl from '~/styles/example/$withParam.css';"
     );
   });
+
+  it('--nameAndDirectoryFormat=as-provided', async () => {
+    await applicationGenerator(tree, { name: 'demo' });
+    await routeGenerator(tree, {
+      path: 'apps/demo/app/routes/example/$withParam.tsx',
+      nameAndDirectoryFormat: 'as-provided',
+      style: 'none',
+      loader: false,
+      action: false,
+      meta: false,
+      skipChecks: false,
+    });
+    await styleGenerator(tree, {
+      path: 'apps/demo/app/routes/example/$withParam.tsx',
+      nameAndDirectoryFormat: 'as-provided',
+    });
+    const content = tree.read(
+      'apps/demo/app/routes/example/$withParam.tsx',
+      'utf-8'
+    );
+
+    expect(content).toMatch(
+      "import stylesUrl from '../../styles/example/$withParam.css';"
+    );
+  });
 });


### PR DESCRIPTION
- feat(remix): add consistent path generation for route
- feat(remix): add consistent path generation for loader
- feat(remix): add consistent path generation for meta
- feat(remix): add consistent path generation for action
- feat(remix): add consistent path generation for style
- feat(remix): add consistent path generation for resource route
- feat(remix): add consistent path generation for error boundary
