### PR TITLE
fix(nx-ignore): install swc to transpile local plugins

### DIFF
--- a/packages/nx-ignore/src/index.ts
+++ b/packages/nx-ignore/src/index.ts
@@ -149,6 +149,11 @@ function installTempNx(root: string, plugins: string[]): string | null {
       nx: deps['nx'],
       typescript: deps['typescript'],
     };
+    // SWC is required when transpiling local plugins
+    if (deps['@swc/core'] && deps['@swc-node/register']) {
+      json.dependencies['@swc/core'] = deps['@swc/core'];
+      json.dependencies['@swc-node/register'] = deps['@swc-node/register'];
+    }
     let devkitNeeded = false;
     plugins.forEach((plugin) => {
       if (deps[plugin]) {


### PR DESCRIPTION
When using local plugins, `nx-ignore` also needs to install SWC to transpile `*.ts` files.