### PR TITLE
fix(nx-ignore): support plugin object in nx.json

### DIFF
--- a/packages/nx-ignore/src/index.ts
+++ b/packages/nx-ignore/src/index.ts
@@ -116,10 +116,12 @@ function logDebug(s: string) {
   if (isVerbose) console.log(s);
 }
 
-function findThirdPartyPlugins(root: string) {
+function findThirdPartyPlugins(root: string): string[] {
   const nxJson = require(join(root, 'nx.json'));
   return (
-    nxJson.plugins?.filter((plugin: string) => !plugin.startsWith('.')) ?? []
+    nxJson.plugins
+      ?.map((p: any) => p.plugin ?? p)
+      ?.filter((plugin: string) => !plugin.startsWith('.')) ?? []
   );
 }
 


### PR DESCRIPTION
When using crystal-compat plugins, `nx-ignore` will fail with an error like this:

```
TypeError: plugin.startsWith is not a function
--
14:54:43.692 | at /vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:83:133
14:54:43.692 | at Array.filter (<anonymous>)
14:54:43.692 | at findThirdPartyPlugins (/vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:83:108)
14:54:43.692 | at main (/vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:39:71)
14:54:43.692 | at Object.<anonymous> (/vercel/.npm/_npx/f3975d057d897afd/node_modules/nx-ignore/src/index.js:27:1)
14:54:43.693 | at Module._compile (node:internal/modules/cjs/loader:1256:14)
14:54:43.693 | at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
14:54:43.693 | at Module.load (node:internal/modules/cjs/loader:1119:32)
14:54:43.693 | at Module._load (node:internal/modules/cjs/loader:960:12)
14:54:43.693 | at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:86:12)
```

This is because the plugins as in object notation (e.g. `{ "plugin": "@nx/next/plugin" }`) rather than a string.

This PR fixes this issue so we can use crystal-compat plugins in our workspaces.