### PR TITLE
feat(rspack): add option to keep existing versions of packages for init generator

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -28,10 +28,10 @@
     "license-webpack-plugin": "^4.0.2",
     "sass-loader": "^12.2.0",
     "stylus-loader": "^7.1.0",
-    "@nx/eslint": "^18.0.7"
-  },
-  "peerDependencies": {
-    "@rspack/core": ">= 0.4.0"
+    "@nx/eslint": "^18.0.7",
+    "@rspack/core": "^0.5.6",
+    "@rspack/plugin-react-refresh": "^0.5.6",
+    "@rspack/plugin-minify": "^0.5.6"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -7,10 +7,10 @@ import {
 } from '@nx/devkit';
 import { initGenerator } from '@nx/js';
 import {
+  lessLoaderVersion,
   rspackCoreVersion,
   rspackDevServerVersion,
   rspackPluginMinifyVersion,
-  lessLoaderVersion,
   rspackPluginReactRefreshVersion,
 } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
@@ -49,7 +49,13 @@ export async function rspackInitGenerator(
     devDependencies['@rspack/dev-server'] = rspackDevServerVersion;
   }
 
-  const installTask = addDependenciesToPackageJson(tree, {}, devDependencies);
+  const installTask = addDependenciesToPackageJson(
+    tree,
+    {},
+    devDependencies,
+    undefined,
+    schema.keepExistingVersions
+  );
   tasks.push(installTask);
 
   return runTasksInSerial(...tasks);

--- a/packages/rspack/src/generators/init/schema.d.ts
+++ b/packages/rspack/src/generators/init/schema.d.ts
@@ -5,4 +5,5 @@ export interface InitGeneratorSchema {
   style?: 'none' | 'css' | 'scss' | 'less' | 'styl';
   devServer?: boolean;
   rootProject?: boolean;
+  keepExistingVersions?: boolean;
 }

--- a/packages/rspack/src/generators/init/schema.json
+++ b/packages/rspack/src/generators/init/schema.json
@@ -18,6 +18,12 @@
     "rootProject": {
       "type": "boolean",
       "x-priority": "internal"
+    },
+    "keepExistingVersions": {
+      "type": "boolean",
+      "x-priority": "internal",
+      "description": "Keep existing dependencies versions",
+      "default": false
     }
   },
   "required": []

--- a/packages/rspack/src/utils/with-react.ts
+++ b/packages/rspack/src/utils/with-react.ts
@@ -1,7 +1,6 @@
 import { Configuration } from '@rspack/core';
 import { SharedConfigContext } from './model';
 import { withWeb } from './with-web';
-import ReactRefreshPlugin from "@rspack/plugin-react-refresh";
 
 export function withReact(opts = {}) {
   return function makeConfig(
@@ -15,6 +14,9 @@ export function withReact(opts = {}) {
       options,
       context,
     });
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
 
     const react = {
       runtime: 'automatic',


### PR DESCRIPTION
The `init` generator for `@nx/rspack` does not have the `keepExistingVersions` option which is used by `nx add`.

Add this option to allow `nx add` to invoke the init generator correctly.
