### PR TITLE
fix(rspack): do not depend directly on ajv to allow for correct hoisting

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -22,8 +22,6 @@
     "@nx/js": "^18.0.7",
     "@nx/devkit": "^18.0.7",
     "@phenomnomnominal/tsquery": "~5.0.1",
-    "ajv": "^8.12.0",
-    "ajv-keywords": "5.1.0",
     "less-loader": "11.1.0",
     "license-webpack-plugin": "^4.0.2",
     "sass-loader": "^12.2.0",


### PR DESCRIPTION
We currently depend on `ajv` and `ajv-keywords` directly in `@nx/rspack` which creates incorrect hositing pattern for package managers.

Allow hoisting to occur correctly by not depending directly on these packages. They are defined within `@rspack/dev-server` -> `webpack-dev-server-middleware` already.
