### PR TITLE
fix(rspack): ensure react-refresh is installed

### DIFF
--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -7,11 +7,11 @@ import {
 } from '@nx/devkit';
 import { initGenerator } from '@nx/js';
 import {
-  lessLoaderVersion,
+  lessLoaderVersion, reactRefreshVersion,
   rspackCoreVersion,
   rspackDevServerVersion,
   rspackPluginMinifyVersion,
-  rspackPluginReactRefreshVersion,
+  rspackPluginReactRefreshVersion
 } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
 
@@ -32,6 +32,7 @@ export async function rspackInitGenerator(
     '@rspack/core': rspackCoreVersion,
     '@rspack/plugin-minify': rspackPluginMinifyVersion,
     '@rspack/plugin-react-refresh': rspackPluginReactRefreshVersion,
+    'react-refresh': reactRefreshVersion
   };
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/rspack/src/utils/versions.ts
+++ b/packages/rspack/src/utils/versions.ts
@@ -6,6 +6,7 @@ export const rspackPluginReactRefreshVersion = '~0.5.6';
 export const lessLoaderVersion = '~11.1.3';
 
 export const reactVersion = '~18.2.0';
+export const reactRefreshVersion = '~0.14.0';
 export const reactDomVersion = '~18.2.0';
 export const typesReactVersion = '~18.0.28';
 export const typesReactDomVersion = '~18.0.10';


### PR DESCRIPTION
`@rspack/plugin-react-refresh` requires `react-refresh` but it does not install it.

Ensure `react-refresh` is installed.
