### PR TITLE
fix(nx-ignore): print stdout and stderr when affected graph cannot be generated

### DIFF
--- a/packages/nx-ignore/src/index.ts
+++ b/packages/nx-ignore/src/index.ts
@@ -90,12 +90,20 @@ async function main() {
   logDebug(`\n≫ Comparing ${baseSha}...${headSha}\n`);
 
   const graphJsonPath = join(tmpdir(), '.nx-affected-graph.json');
-  execSync(
-    `npx nx affected:graph --base=${baseSha} --head=${headSha} --file=${graphJsonPath}`,
-    {
-      cwd: root,
-    }
-  );
+  try {
+    execSync(
+      `npx nx affected:graph --base=${baseSha} --head=${headSha} --file=${graphJsonPath}`,
+      {
+        cwd: root,
+      }
+    );
+  } catch (e: any) {
+    if (e.stdout) console.error(e.stdout.toString());
+    if (e.stderr) console.error(e.stderr.toString());
+    exitWithoutBuild(
+      `🛑 - Build cancelled due to the error above (Hint: commit with "[nx deploy]" to force deployment)`
+    );
+  }
   const projects = JSON.parse(
     readFileSync(graphJsonPath).toString()
   ).affectedProjects;


### PR DESCRIPTION
This PR adds logging of both `stdout` and `stderr` when `execSync` fails on generating affected graph.