### PR TITLE
feat(nx-ignore): perform full install when plugins are used and provide escape hatch

### DIFF
--- a/e2e/nx-ignore-e2e/tests/nx-ignore.spec.ts
+++ b/e2e/nx-ignore-e2e/tests/nx-ignore.spec.ts
@@ -6,6 +6,7 @@ import {
   runCommand,
   tmpProjPath,
   uniq,
+  updateFile,
 } from '@nx/plugin/testing';
 
 describe('nx-ignore e2e', () => {
@@ -73,4 +74,40 @@ describe('nx-ignore e2e', () => {
       expect(result).toMatch(/Forced build/);
     });
   }, 120_000);
+
+  describe('Installation strategies', () => {
+    it('should perform a slim installation when Nx plugins are not used', () => {
+      runCommand(`git commit -m "test" --allow-empty`, {});
+
+      const result = runCommand(`npx nx-ignore ${proj} --verbose`, {});
+      expect(result).toMatch(/slim installation/);
+    });
+
+    it('should perform a full installation when Nx plugins are used', () => {
+      updateFile('nx.json', (s) => {
+        const json = JSON.parse(s);
+        json.plugins = ['@nx/jest/plugin'];
+        return JSON.stringify(json);
+      });
+      runCommand(`git commit -m "test" --allow-empty`, {});
+
+      const result = runCommand(`npx nx-ignore ${proj} --verbose`, {});
+      expect(result).toMatch(/full installation/);
+    });
+
+    it('should perform a slim installation when --slim-install is used', () => {
+      updateFile('nx.json', (s) => {
+        const json = JSON.parse(s);
+        json.plugins = ['@nx/jest/plugin'];
+        return JSON.stringify(json);
+      });
+      runCommand(`git commit -m "test" --allow-empty`, {});
+
+      const result = runCommand(
+        `npx nx-ignore ${proj} --slim-install --verbose`,
+        {}
+      );
+      expect(result).toMatch(/slim installation/);
+    });
+  });
 });

--- a/packages/nx-ignore/README.md
+++ b/packages/nx-ignore/README.md
@@ -17,6 +17,7 @@ For Vercel, under the `Settings > Git` section, use this script in `Ignored Buil
 - `--base` - Set a custom base SHA to compare changes (defaults to `CACHED_COMMIT_REF` on Netlify or `VERCEL_GIT_PREVIOUS_SHA` on Vercel)
 - `--plugins` - List of Nx plugins required (i.e. plugins that extend the Nx graph). Default plugins are read from nx.json.
 - `--root` - Set a custom workspace root (defaults to current working directory).
+- `--slim-install` - Install only Nx and necessary plugins to speed up the script (defaults to true when not using plugin, and false when plugins are used).
 - `--verbose` - Log more details information for debugging purposes.
 
 ### Skipping and forcing deployment


### PR DESCRIPTION
This PR ensures that full installation is performed when using Nx plugins. There isn't a guarantee that all transient dependencies will be installed, which can lead to errors when constructing graph.

Users can pass in `--slim-install` to override this behavior.