### PR TITLE
feat(nx-ignore): use slim installation on Netlify to avoid script timeout

### DIFF
--- a/packages/nx-ignore/README.md
+++ b/packages/nx-ignore/README.md
@@ -14,7 +14,8 @@ For Vercel, under the `Settings > Git` section, use this script in `Ignored Buil
 
 ### Options
 
-- `--base` - Set a custom base SHA to compare changes (defaults to `CACHED_COMMIT_REF` on Netlify or `VERCEL_GIT_PREVIOUS_SHA` on Vercel)
+- `--additional-packages` - List of additional npm packages to install when using `--slim-install`. Use this for packages required in configuration files that infer Nx targets (e.g. `@playwright/test`). Defaults to a list of known packages required by Nx and Nx plugins.
+- `--base` - Set a custom base SHA to compare changes (defaults to `CACHED_COMMIT_REF` on Netlify or `VERCEL_GIT_PREVIOUS_SHA` on Vercel).
 - `--plugins` - List of Nx plugins required (i.e. plugins that extend the Nx graph). Default plugins are read from nx.json.
 - `--root` - Set a custom workspace root (defaults to current working directory).
 - `--slim-install` - Install only Nx and necessary plugins to speed up the script (defaults to true when not using plugin, and false when plugins are used).
@@ -37,3 +38,17 @@ Skip nx-ignore check and force deployment:
 ## How it works
 
 The `nx-ignore` command uses Nx to determine whether the current commit affects the specified app. It exits with an error code (1) when the app is affected, which tells the platform to continue the build, otherwise it exits successfully, which tells the platform to cancel the build.
+
+## Troubleshooting
+
+### Error `Failed to process project graph` occurs on Netlify
+
+When `plugins` are used in `nx.json`, Nx infers projects and targets through those plugins via their corresponding configuration files. For example, `@nx/next/plugin` infers projects and targets from `next.config.js` files. This means that modules imported in `next.config.js` must be present in order for Nx to work correctly.
+
+If you run into the `Failed to process project graph` error, it means that some of the packages are missing. To debug what packages are missing, run `npx nx-ignore@latest <app> --verbose --slim-install` locally, and you should see and error with the missing package. You can also run `npx nx show projects` to debug any missing packages, after running the `npx nx-ignore` command.
+
+Use the `--additional-packages` option to install the missing packages as detected above. For example,
+
+```
+npx nx-ignore@latest <app> --verbose --slim-install --additional-packages=@playwright/test,jest-environment-jsdom
+```


### PR DESCRIPTION
Netlify deployments currently has two problems:

1. npm packages are not installed prior to calling `npx nx-ignore`.
2. There is a three minute limit for the ignore script.

For Nx plugins that infer targets from config files, we should do a full installation to ensure packages used by config files are present. Otherwise errors like missing `@playwright/test` or `next/constants` will occur. On Vercel, this works fine because there isn't a limit to the ignore script (at least it is reasonable long). On Netlify, the three minute limit for ignore script means full installation will almost always fail.

The fix for this issue is to detect whether we're on Netlify or not (checking `NETLIFY` env var). If we're on Netlify, then perform a slim installation. And to make it more compatible with Project Crystal, we will install known packages that are used in config files (if they are in the root `package.json`). Users can also manually pass `--additional-packages` option if we miss a package.

Note: On the ocean repo, `nx-ignore` goes from 145s to 23s on my local machine.