### PR TITLE
fix(nx-ignore): include ts-jest and babel-jest and other potential transforms

### DIFF
--- a/packages/nx-ignore/src/index.ts
+++ b/packages/nx-ignore/src/index.ts
@@ -281,6 +281,7 @@ function detectRequiredPackages(root: string): Record<string, string> {
     /^eslint-/,
     /^jest$/,
     /^jest-/,
+    /-jest$/, // ts-jest, babel-jest
     /^next$/,
     /^nuxt$/,
     /@playwright\//,


### PR DESCRIPTION
ts-jest and babel-jest should be installed if they exist