### PR TITLE
feat(rspack): add the ability to not get the default html build plugin

### DIFF
--- a/packages/rspack/src/utils/with-react.ts
+++ b/packages/rspack/src/utils/with-react.ts
@@ -1,8 +1,10 @@
 import { Configuration } from '@rspack/core';
 import { SharedConfigContext } from './model';
-import { withWeb } from './with-web';
+import { withWeb, WithWebOptions } from './with-web';
 
-export function withReact(opts = {}) {
+export type WithReactOptions = Omit<WithWebOptions, 'cssModules'>;
+
+export function withReact(opts:WithWebOptions = {}) {
   return function makeConfig(
     config: Configuration,
     { options, context }: SharedConfigContext

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -7,6 +7,7 @@ export interface WithWebOptions {
     includePaths?: string[];
   };
   cssModules?: boolean;
+  htmlPlugins?: false | Configuration['plugins'];
 }
 
 export function withWeb(opts: WithWebOptions = {}) {
@@ -51,9 +52,11 @@ export function withWeb(opts: WithWebOptions = {}) {
           {
             test: /\.css$/,
             type: 'css',
-            use: [{
-              loader: require.resolve('postcss-loader'),
-            }]
+            use: [
+              {
+                loader: require.resolve('postcss-loader'),
+              },
+            ],
           },
           {
             test: /\.scss$|\.sass$/,
@@ -107,14 +110,24 @@ export function withWeb(opts: WithWebOptions = {}) {
       },
       plugins: [
         ...config.plugins,
-        new rspack.HtmlRspackPlugin({
-          template: options.indexHtml
-            ? path.join(context.root, options.indexHtml)
-            : path.join(projectRoot, 'src/index.html'),
-        }),
+        ...(() => {
+          if (opts.htmlPlugins === false) {
+            return [];
+          }
+          if (opts.htmlPlugins) {
+            return opts.htmlPlugins;
+          }
+          return [
+            new rspack.HtmlRspackPlugin({
+              template: options.indexHtml
+                ? path.join(context.root, options.indexHtml)
+                : path.join(projectRoot, 'src/index.html'),
+            }),
+          ];
+        })(),
         new rspack.DefinePlugin({
           'process.env.NODE_ENV': isProd ? "'production'" : "'development'",
-        })
+        }),
       ],
     };
   };


### PR DESCRIPTION
I need the ability not to use the default plugin to create the html file.

With this PR it is possible to set `htmlPlugins` to `false` to not have it compiled.

No side effect expected on the other targets.