### PR TITLE
fix: remove `port` to correctly inherit real port value

### DIFF
--- a/packages/rspack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/rspack/src/executors/dev-server/dev-server.impl.ts
@@ -49,7 +49,6 @@ export default async function* runExecutor(
   devServerConfig = {
     ...devServerConfig,
     ...firstCompiler.options.devServer,
-    port: devServerConfig.port,
   };
 
   const baseUrl = `http://localhost:${options.port ?? 4200}`;


### PR DESCRIPTION
I think #416 inadvertently broke user passed in `port` and a previous fix could now be removed (see https://github.com/nrwl/nx-labs/commit/d2b40240de6200d4b7e65ef39aefbe0694b58c00).