### PR TITLE
feat(php): add default inputs for production files that excludes PHP tests

### DIFF
--- a/packages/php/src/generators/init/init.spec.ts
+++ b/packages/php/src/generators/init/init.spec.ts
@@ -29,17 +29,40 @@ describe('@nx/php:init', () => {
         skipPackageJson: false,
       });
       const nxJson = readNxJson(tree);
-      expect(nxJson.plugins).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "options": Object {
-              "ignorePattern": "**/{tests,fixtures}/**",
-              "installTargetName": "install",
-              "updateTargetName": "update",
-            },
-            "plugin": "@nx/php/composer",
+      expect(nxJson).toMatchInlineSnapshot(`
+        Object {
+          "affected": Object {
+            "defaultBase": "main",
           },
-        ]
+          "namedInputs": Object {
+            "default": Array [
+              "{projectRoot}/**/*",
+            ],
+            "production": Array [
+              "default",
+              "!{projectRoot}/**/*.md",
+              "!{projectRoot}/(test|tests|Test|Tests)/**/*",
+            ],
+          },
+          "plugins": Array [
+            Object {
+              "options": Object {
+                "ignorePattern": "**/{tests,fixtures}/**",
+                "installTargetName": "install",
+                "updateTargetName": "update",
+              },
+              "plugin": "@nx/php/composer",
+            },
+          ],
+          "targetDefaults": Object {
+            "build": Object {
+              "cache": true,
+            },
+            "lint": Object {
+              "cache": true,
+            },
+          },
+        }
       `);
     });
 

--- a/packages/php/src/phpunit/plugin/create-nodes.ts
+++ b/packages/php/src/phpunit/plugin/create-nodes.ts
@@ -162,6 +162,7 @@ async function buildTargets(
       isRootComposerJson
         ? `${options.testCommand} -c ${projectRoot}`
         : options.testCommand,
+      testPkg,
       projectRoot,
       isRootComposerJson ? '.' : projectRoot,
       context
@@ -171,6 +172,7 @@ async function buildTargets(
       isRootComposerJson
         ? `./vendor/bin/phpunit -c ${projectRoot}`
         : `./vendor/bin/phpunit`,
+      testPkg,
       projectRoot,
       isRootComposerJson ? '.' : projectRoot,
       context
@@ -180,6 +182,7 @@ async function buildTargets(
       isRootComposerJson
         ? `./vendor/bin/simple-phpunit -c ${projectRoot}`
         : `./vendor/bin/simple-phpunit`,
+      testPkg,
       projectRoot,
       isRootComposerJson ? '.' : projectRoot,
       context
@@ -199,6 +202,7 @@ function getTestPackageName(composerJson: ComposerJson): string | null {
 
 function createPhpUnitTarget(
   command: string,
+  testPkg: string,
   projectRoot: string,
   cwd: string,
   context: CreateNodesContext
@@ -208,7 +212,7 @@ function createPhpUnitTarget(
     command,
     cache: true,
     dependsOn: ['install', 'composer:install', 'composer-install'],
-    inputs: getInputs(namedInputs),
+    inputs: getInputs(namedInputs, testPkg),
     options: {
       cwd,
     },
@@ -233,11 +237,13 @@ function normalizeOptions(options: ComposerPluginOptions): NormalizedOptions {
 }
 
 function getInputs(
-  namedInputs: NxJsonConfiguration['namedInputs']
+  namedInputs: NxJsonConfiguration['namedInputs'],
+  testPkg: string
 ): TargetConfiguration['inputs'] {
   return [
     ...('production' in namedInputs
       ? ['default', '^production']
       : ['default', '^default']),
+    { externalDependencies: [testPkg] },
   ];
 }


### PR DESCRIPTION
Currently, `nx init` and `nx add @nx/php` does not configure `inputs` in `nx.json` to ignore test files. Since PHP tests are almost always under one of the following:

- tests
- Tests
- test
- test

We can ignore them from production files, which will help subsequent build and other targets.

This also helps discoverability, so users can see how to update `nx.json` to get the right fileset they need.

## Note

Unlike in the JS world, PHP is more like Java in that tests are almost always in one of the listed folders. And then the autoload is configured like this:

```
    "autoload": {
        "psr-4": {
            "App\\": "src/"
        }
    },
    "autoload-dev": {
        "psr-4": {
            "App\\Tests\\": "tests/"
        }
    }
```