### PR TITLE
fix(php): ignore vendor files explicitly if they are not in gitignore

### DIFF
--- a/packages/php/src/composer/plugin/create-nodes.ts
+++ b/packages/php/src/composer/plugin/create-nodes.ts
@@ -1,22 +1,22 @@
 import {
-  type CreateNodesContext,
-  createNodesFromFiles,
-  type CreateNodesFunction,
-  type CreateNodesV2,
-  type ProjectConfiguration,
-  type ProjectGraphExternalNode,
-  readJsonFile,
-  writeJsonFile,
+type CreateNodesContext,
+createNodesFromFiles,
+type CreateNodesFunction,
+type CreateNodesV2,
+type ProjectConfiguration,
+type ProjectGraphExternalNode,
+readJsonFile,
+writeJsonFile,
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { minimatch } from 'minimatch';
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname,join } from 'node:path';
 import { toProjectName } from 'nx/src/config/to-project-name';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { maybeGetLockFiles } from '../../utils/create-nodes';
-import { ComposerJson, ComposerLock } from '../../utils/model';
+import { ComposerJson,ComposerLock } from '../../utils/model';
 
 export interface ComposerPluginOptions {
   installTargetName?: string | false;
@@ -138,9 +138,17 @@ function makeCreateNodesFromComposerJson(
     context: CreateNodesContext
   ) => {
     const projectRoot = dirname(configFilePath);
+    // In case users use "@nx/php/composer" in nx.json without passing in options.
+    options = options ?? {};
 
     // The lockfile is just used to parse out external dependencies, we'll create the projects from composer.json only.
     if (configFilePath.endsWith('.lock')) return {};
+
+    if (
+      configFilePath.startsWith('vendor/') ||
+      minimatch(configFilePath, `${projectRoot}/vendor/**`)
+    )
+      return {};
 
     if (
       options.ignorePattern &&

--- a/packages/php/src/phpunit/plugin/create-nodes.ts
+++ b/packages/php/src/phpunit/plugin/create-nodes.ts
@@ -14,6 +14,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
+import { minimatch } from 'minimatch';
 import { toProjectName } from 'nx/src/config/to-project-name';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
@@ -89,6 +90,11 @@ function makeCreateNodesFromComposerJson(
     ) {
       return {};
     }
+    if (
+      configFilePath.startsWith('vendor/') ||
+      minimatch(configFilePath, `${projectRoot}/vendor/**`)
+    )
+      return {};
 
     // If `project.json` does not provide the name, we have to read it from `composer.json` or else graph creation fails.
     if (existsSync(join(context.workspaceRoot, projectRoot, 'composer.json'))) {


### PR DESCRIPTION
Some PHP projects commit their `vendor/` folder to git. This PR ensures that we don't infer them as workspace projects if that's the case (i.e. not added to `.gitignore` or `.nxignore`).