### PR TITLE
ci(repo): add secure CI publish workflow for @nx/php

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: publish
+
+on:
+  # Manual trigger only — a maintainer starts a release from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version specifier (e.g. "1.2.3", "1.2.3-beta.1", or a bump like "patch"/"minor"/"prerelease")'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run — build and preview the release without publishing or pushing anything. Uncheck to perform a real release.'
+        required: false
+        default: true
+        type: boolean
+
+run-name: ${{ inputs.dry-run && format('Release Dry-Run ({0})', inputs.version) || format('Release {0}', inputs.version) }}
+
+jobs:
+  publish:
+    name: Publish
+    # Prevent forks from ever running the publish workflow.
+    if: ${{ github.repository_owner == 'nrwl' }}
+    runs-on: ubuntu-latest
+    # Deployment environment — configure required reviewers / branch
+    # restrictions on the "npm-registry" environment in repo settings to
+    # gate every publish behind a human approval.
+    environment: npm-registry
+    permissions:
+      # Required for npm OIDC trusted publishing (no stored npm token) + provenance.
+      id-token: write
+      # Required for nx release to push the changelog commit, git tags, and GitHub release.
+      contents: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Full history + tags so nx release can resolve previous versions and generate the changelog.
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup dev tools with mise
+        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+
+      # OIDC trusted publishing + provenance requires a recent npm.
+      - name: Use latest npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies with bun
+        run: bun install --frozen-lockfile
+
+      - name: Release
+        run: |
+          bunx nx release ${{ inputs.version }} --yes ${{ inputs.dry-run && '--dry-run' || '' }}

--- a/nx.json
+++ b/nx.json
@@ -68,8 +68,18 @@
   "nxCloudUrl": "https://staging.nx.app",
   "defaultBase": "main",
   "release": {
-    "projects": ["packages/*"],
+    "projects": ["php"],
     "projectsRelationship": "independent",
+    "git": {
+      "commit": false,
+      "tag": true
+    },
+    "changelog": {
+      "projectChangelogs": {
+        "file": false,
+        "createRelease": "github"
+      }
+    },
     "version": {
       "preVersionCommand": "bunx nx run-many -t build",
       "currentVersionResolver": "registry",


### PR DESCRIPTION
## Summary

Replaces the manual, laptop-run `release-it` flow with a CI-based publish workflow that uses **npm OIDC trusted publishing**. Modeled on the release setup in `nrwl/nx` and `nrwl/ocean`.

### Why

Today releases run from a developer's laptop via `scripts/nx-release.mjs` + `npm adduser` — long-lived personal npm credentials, no audit trail, no approval gate, no provenance.

### Changes

**`.github/workflows/publish.yml`** (new)
- `workflow_dispatch`-only trigger with `version` and `dry-run` inputs (`dry-run` defaults to `true`)
- Runs `nx release` on a GitHub Actions runner
- OIDC trusted publishing (`id-token: write`) — no stored `NPM_TOKEN`, npm provenance included
- `environment: npm-registry` — gates publishing behind reviewer approval
- SHA-pinned actions; `repository_owner == 'nrwl'` fork guard

**`nx.json`** release config
- Scoped `release.projects` to `["php"]` — `nx release` targets only `@nx/php`. `nx-ignore` is on a separate version line (`19.8.0` vs `0.0.x`) and hasn't shipped in ~20 months, so it's no longer auto-released (stays published on npm as-is).
- `git.commit: false`, `git.tag: true` — no version-bump commit pushed to `main`; only tags
- `changelog.projectChangelogs`: `file: false` + `createRelease: "github"` — posts a GitHub Release without writing `CHANGELOG.md`

Net effect: GitHub Releases + npm publish with **zero writes back to `main`**.

## Required manual setup before first release

- [x] Create the `npm-registry` deployment environment with required reviewers
- [x] Register `@nx/php` as a trusted publisher on npmjs.com (repo `nrwl/nx-labs`, workflow `publish.yml`, environment `npm-registry`)

## Notes

The workflow file must land on `main` before `workflow_dispatch` becomes available in the Actions tab.